### PR TITLE
Centralize pandas options

### DIFF
--- a/solarwindpy/__init__.py
+++ b/solarwindpy/__init__.py
@@ -24,8 +24,14 @@ from .core import (
 from . import core, plotting, solar_activity, tools, fitfunctions
 from . import instabilities  # noqa: F401
 
-pd.set_option("mode.chained_assignment", "raise")
-# pd.set_option("mode.use_inf_as_na", True)
+
+def _configure_pandas() -> None:
+    """Configure global pandas options used throughout SolarWindPy."""
+
+    pd.set_option("mode.chained_assignment", "raise")
+
+
+_configure_pandas()
 
 Plasma = core.plasma.Plasma
 at = alfvenic_turbulence

--- a/solarwindpy/core/__init__.py
+++ b/solarwindpy/core/__init__.py
@@ -1,2 +1,1 @@
-r""":py:mod:`solarwindpy` core classes.
-"""
+r""":py:mod:`solarwindpy` core classes."""

--- a/solarwindpy/core/alfvenic_turbulence.py
+++ b/solarwindpy/core/alfvenic_turbulence.py
@@ -23,7 +23,6 @@ from collections import namedtuple
 # We rely on views via DataFrame.xs to reduce memory size and do not
 # `.copy(deep=True)`, so we want to make sure that this doesn't
 # accidentally cause a problem.
-pd.set_option("mode.chained_assignment", "raise")
 
 try:
     from . import base
@@ -100,8 +99,7 @@ class AlfvenicTurbulence(base.Core):
 
     @property
     def data(self):
-        r"""Mean-subtracted quantities used to calculated Elsasser variables.
-        """
+        r"""Mean-subtracted quantities used to calculated Elsasser variables."""
         return self._data
 
     @property
@@ -113,20 +111,17 @@ class AlfvenicTurbulence(base.Core):
 
     @property
     def measurements(self):
-        r"""Measurements used to calcualte mean-subtracted `data`.
-        """
+        r"""Measurements used to calcualte mean-subtracted `data`."""
         return self._measurements
 
     @property
     def velocity(self):
-        r"""Velocity in Plasma's v-units.
-        """
+        r"""Velocity in Plasma's v-units."""
         return self.data.loc[:, "v"]
 
     @property
     def v(self):
-        r"""Shortcut for `AlfvenicTurbulence.velocity`
-        """
+        r"""Shortcut for `AlfvenicTurbulence.velocity`"""
         return self.velocity
 
     @property
@@ -138,8 +133,7 @@ class AlfvenicTurbulence(base.Core):
 
     @property
     def b(self):
-        r"""Shortcut for `AlfvenicTurbulence.bfield`.
-        """
+        r"""Shortcut for `AlfvenicTurbulence.bfield`."""
         return self.bfield
 
     @property
@@ -151,28 +145,24 @@ class AlfvenicTurbulence(base.Core):
 
     @property
     def z_plus(self):
-        r"""Z+ Elsasser variable.
-        """
+        r"""Z+ Elsasser variable."""
         zp = self.v.add(self.b, axis=1)
         return zp
 
     @property
     def zp(self):
-        r"""Shortcut for `AlfvenicTurbulence.z_plus`.
-        """
+        r"""Shortcut for `AlfvenicTurbulence.z_plus`."""
         return self.z_plus
 
     @property
     def z_minus(self):
-        r"""Z- Elsasser variable.
-        """
+        r"""Z- Elsasser variable."""
         zm = self.v.subtract(self.b, axis=1)
         return zm
 
     @property
     def zm(self):
-        r"""Shortcut for `AlfvenicTurbulence.z_minus`.
-        """
+        r"""Shortcut for `AlfvenicTurbulence.z_minus`."""
         return self.z_minus
 
     @property

--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -13,7 +13,6 @@ from typing import Any, Tuple, Union
 import numpy as np
 import pandas as pd
 from pandas import MultiIndex as MI
-pd.set_option("mode.chained_assignment", "raise")
 
 try:
     from . import units_constants as uc
@@ -76,7 +75,7 @@ class Core(ABC):
             # return eq_data.all().all()
             eq_data = self.data.equals(other.data)
             return eq_data
-        
+
         except ValueError as e:
             if "Can only compare identically-labeled DataFrame objects" in str(e):
                 return False
@@ -142,11 +141,13 @@ class Core(ABC):
 
         slist = species[0].split("+") if len(species) == 1 else species
         return tuple(sorted(slist))
-    
+
     @abstractmethod
     def _clean_species_for_setting(self, *species: str) -> Tuple[str, ...]:
         if not species:
-            raise ValueError(f"You must specify a species to instantiate a {self.__class__.__name__}.")
+            raise ValueError(
+                f"You must specify a species to instantiate a {self.__class__.__name__}."
+            )
         return species
 
     def _verify_datetimeindex(self, data: pd.DataFrame) -> None:
@@ -191,7 +192,7 @@ class Base(Core):
 
     # def __getattr__(self, attr: str) -> Any:
     #     if attr in self._cache:
-    #         return self._cache[attr]       
+    #         return self._cache[attr]
 
     #     if hasattr(self._data, attr):
     #         value = getattr(self._data, attr)
@@ -204,20 +205,20 @@ class Base(Core):
     #         return self._cache[attr]
 
     #     raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'")
-     
-        # try:
-        #     out = getattr(self.data, attr)
-        #     if isinstance(out, pd.core.generic.NDFrame) and out.empty:
-        #         raise ValueError(f"`{attr}` attr returns an empty NDFrame")
-        #     return out
-        # except AttributeError:
-        #     raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'")
+
+    # try:
+    #     out = getattr(self.data, attr)
+    #     if isinstance(out, pd.core.generic.NDFrame) and out.empty:
+    #         raise ValueError(f"`{attr}` attr returns an empty NDFrame")
+    #     return out
+    # except AttributeError:
+    #     raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{attr}'")
 
     # # Implement common DataFrame properties
     # @property
     # def index(self):
     #     return self._data.index
-    
+
     # # Implement common DataFrame methods
     # def loc(self, *args, **kwargs):
     #     return self._data.loc(*args, **kwargs)

--- a/solarwindpy/core/ions.py
+++ b/solarwindpy/core/ions.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 import pandas as pd
 from typing import Union
 
-pd.set_option("mode.chained_assignment", "raise")
-
 try:
     from . import base
     from . import vector
@@ -57,7 +55,7 @@ class Ion(base.Base):
         Set the species of the ion.
     set_data(data: pd.DataFrame)
         Set the data for the ion.
-        """
+    """
 
     def __init__(self, data: pd.DataFrame, species: str):
         self.set_species(species)
@@ -66,10 +64,7 @@ class Ion(base.Base):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Ion):
             return NotImplemented
-        return (
-            self.species == other.species
-            and self.data.equals(other.data)
-        )
+        return self.species == other.species and self.data.equals(other.data)
 
     def set_species(self, species: str) -> None:
         """

--- a/solarwindpy/core/plasma.py
+++ b/solarwindpy/core/plasma.py
@@ -36,7 +36,6 @@ import itertools
 # We rely on views via DataFrame.xs to reduce memory size and do not
 # `.copy(deep=True)`, so we want to make sure that this doesn't
 # accidentally cause a problem.
-pd.set_option("mode.chained_assignment", "raise")
 
 try:
     from . import base
@@ -154,14 +153,12 @@ class Plasma(base.Base):
 
     @property
     def spacecraft(self):
-        r"""`Spacecraft` object stored in `plasma`.
-        """
+        r"""`Spacecraft` object stored in `plasma`."""
         return self._spacecraft
 
     @property
     def sc(self):
-        r"""Shortcut to `spacecraft`.
-        """
+        r"""Shortcut to `spacecraft`."""
         return self.spacecraft
 
     @property
@@ -182,8 +179,7 @@ class Plasma(base.Base):
 
     @property
     def aux(self):
-        r"""Shortcut to :py:meth:`auxiliary_data`.
-        """
+        r"""Shortcut to :py:meth:`auxiliary_data`."""
         return self.auxiliary_data
 
     @property
@@ -438,14 +434,12 @@ class Plasma(base.Base):
 
     @property
     def species(self):
-        r"""Tuple of species contained in plasma.
-        """
+        r"""Tuple of species contained in plasma."""
         return self._species
 
     @property
     def ions(self):
-        r"""`pd.Series` containing the ions.
-        """
+        r"""`pd.Series` containing the ions."""
         return self._ions
 
     def _set_ions(self):
@@ -535,8 +529,7 @@ class Plasma(base.Base):
             )
 
     def set_data(self, new):
-        r"""Set the data and log statistics about it.
-        """
+        r"""Set the data and log statistics about it."""
         #         assert isinstance(new, pd.DataFrame)
         super(Plasma, self).set_data(new)
 
@@ -629,8 +622,7 @@ class Plasma(base.Base):
 
     @property
     def bfield(self):
-        r"""Magnetic field data.
-        """
+        r"""Magnetic field data."""
         return self._bfield
 
     @property
@@ -706,8 +698,7 @@ class Plasma(base.Base):
         return rho
 
     def rho(self, *species):
-        r"""Shortcut to :py:meth:`mass_density`.
-        """
+        r"""Shortcut to :py:meth:`mass_density`."""
         return self.mass_density(*species)
 
     def thermal_speed(self, *species):
@@ -741,8 +732,7 @@ class Plasma(base.Base):
         return w
 
     def w(self, *species):
-        r"""Shortcut to :py:meth:`thermal_speed`.
-        """
+        r"""Shortcut to :py:meth:`thermal_speed`."""
         return self.thermal_speed(*species)
 
     def pth(self, *species):
@@ -855,7 +845,7 @@ class Plasma(base.Base):
         bsq = self.bfield.mag.pow(2)
         beta = pth.divide(bsq, axis=0)
 
-        units = self.units.pth / (self.units.b ** 2.0)
+        units = self.units.pth / (self.units.b**2.0)
         coeff = 2.0 * self.constants.misc.mu0 * units
         beta *= coeff
         return beta
@@ -951,7 +941,9 @@ species: {}
                     names=["S"],
                     sort=True,
                 )
-                rv = v.multiply(rhos, axis=1, level="S").T.groupby(level="C").sum().T #sum(axis=1, level="C")
+                rv = (
+                    v.multiply(rhos, axis=1, level="S").T.groupby(level="C").sum().T
+                )  # sum(axis=1, level="C")
                 v = rv.divide(rhos.sum(axis=1), axis=0)
                 v = vector.Vector(v)
 
@@ -1027,7 +1019,7 @@ species: {}
             msg = "Must have >1 species to calculate dynamic pressure.\nRequested: {}"
             raise ValueError(msg.format(species))
 
-        const = 0.5 * self.units.rho * (self.units.dv ** 2.0) / self.units.pth
+        const = 0.5 * self.units.rho * (self.units.dv**2.0) / self.units.pth
 
         if not project_m2q:
             # Calculate as m*v
@@ -1083,8 +1075,7 @@ species: {}
         return pdv
 
     def pdv(self, *species, project_m2q=False):
-        r"""Shortcut to :py:meth:`pdynamic`.
-        """
+        r"""Shortcut to :py:meth:`pdynamic`."""
         return self.pdynamic(*species, project_m2q=project_m2q)
 
     def sound_speed(self, *species):
@@ -1115,8 +1106,7 @@ species: {}
         return cs
 
     def cs(self, *species):
-        r""" Shortcut to :py:meth:`sound_speed`.
-        """
+        r"""Shortcut to :py:meth:`sound_speed`."""
         return self.sound_speed(*species)
 
     def ca(self, *species):
@@ -1208,7 +1198,7 @@ species: {}
         dp = dp.sum(axis=1, level="S" if multi_species else None)
 
         mu0 = self.constants.misc.mu0
-        coeff = mu0 * self.units.pth / (self.units.b ** 2.0)
+        coeff = mu0 * self.units.pth / (self.units.b**2.0)
 
         afsq = 1.0 + (dp.divide(bsq, axis=0) * coeff)
 
@@ -1325,8 +1315,8 @@ species: {}
         T0 = self.ions.loc[s0].temperature.scalar * units.temperature * constants.kb.eV
         T1 = self.ions.loc[s1].temperature.scalar * units.temperature * constants.kb.eV
 
-        r0 = n0.multiply(z0 ** 2.0).divide(T0, axis=0)
-        r1 = n1.multiply(z1 ** 2.0).divide(T1, axis=0)
+        r0 = n0.multiply(z0**2.0).divide(T0, axis=0)
+        r1 = n1.multiply(z1**2.0).divide(T1, axis=0)
         right = r0.add(r1).pipe(np.sqrt)
 
         left = z0 * z1 * (a0 + a1) / (a0 * T1).add(a1 * T0, axis=0)
@@ -1410,12 +1400,14 @@ species: {}
         ma = constants.m.loc[sa]
         masses = constants.m.loc[[sa, sb]]
         mu = masses.product() / masses.sum()
-        coeff = qabsq / (4.0 * np.pi * constants.misc.e0 ** 2.0 * ma * mu)
+        coeff = qabsq / (4.0 * np.pi * constants.misc.e0**2.0 * ma * mu)
 
         lnlambda = self.lnlambda(sa, sb) * units.lnlambda
         nb = self.ions.loc[sb].n * units.n
 
-        w = pd.concat({s: self.ions.loc[s].w.data.par for s in [sa, sb]}, axis=1, sort=True)
+        w = pd.concat(
+            {s: self.ions.loc[s].w.data.par for s in [sa, sb]}, axis=1, sort=True
+        )
         wab = w.pow(2.0).sum(axis=1).pipe(np.sqrt) * units.w
 
         dv = self.dv(sa, sb).magnitude * units.dv
@@ -1704,7 +1696,9 @@ species: {}
             niqi = ni.multiply(qi, axis=1, level="S")
             ne = niqi.sum(axis=1)
             # niqivi = vi.multiply(niqi, axis=1, level="S").sum(axis=1, level="C")
-            niqivi = vi.multiply(niqi, axis=1, level="S").T.groupby(level="C").sum().T #sum(axis=1, level="C")
+            niqivi = (
+                vi.multiply(niqi, axis=1, level="S").T.groupby(level="C").sum().T
+            )  # sum(axis=1, level="C")
 
         ve = niqivi.divide(ne, axis=0)
 
@@ -1810,7 +1804,7 @@ species: {}
         #        print("<qpar>", type(qs), qs,
         #              sep="\n")
 
-        coeff = self.units.rho * (self.units.v ** 3.0) / self.units.qpar
+        coeff = self.units.rho * (self.units.v**3.0) / self.units.qpar
         q = coeff * qs
         return q
 
@@ -1869,8 +1863,7 @@ species: {}
         return turb
 
     def S(self, *species):
-        r"""Shortcut to :py:meth:`specific_entropy`.
-        """
+        r"""Shortcut to :py:meth:`specific_entropy`."""
         return self.specific_entropy(*species)
 
     def specific_entropy(self, *species):

--- a/solarwindpy/core/spacecraft.py
+++ b/solarwindpy/core/spacecraft.py
@@ -11,7 +11,6 @@ import numpy as np
 # We rely on views via DataFrame.xs to reduce memory size and do not
 # `.copy(deep=True)`, so we want to make sure that this doesn't
 # accidentally cause a problem.
-pd.set_option("mode.chained_assignment", "raise")
 
 try:
     from . import base
@@ -85,14 +84,12 @@ class Spacecraft(base.Base):
 
     @property
     def frame(self):
-        r"""Spacecraft's frame of reference (e.g. GSE, HCI, etc.).
-        """
+        r"""Spacecraft's frame of reference (e.g. GSE, HCI, etc.)."""
         return self._frame
 
     @property
     def name(self):
-        r"""Spacecraft name (e.g. WIND, PSP)
-        """
+        r"""Spacecraft name (e.g. WIND, PSP)"""
         return self._name
 
     @property
@@ -107,8 +104,7 @@ class Spacecraft(base.Base):
 
     @property
     def r(self):
-        r"""Shortcut to :py:meth:`position`.
-        """
+        r"""Shortcut to :py:meth:`position`."""
         return self.position
 
     @property
@@ -126,8 +122,7 @@ class Spacecraft(base.Base):
 
     @property
     def carrington(self):
-        r"""Carrington latitude and longitude.
-        """
+        r"""Carrington latitude and longitude."""
         try:
             return self.data.xs("carr", axis=1, level="M").loc[:, ("lat", "lon")]
         except KeyError as e:  # noqa: F841
@@ -135,8 +130,7 @@ class Spacecraft(base.Base):
 
     @property
     def distance2sun(self):
-        r"""Radial distance to Sun in meters.
-        """
+        r"""Radial distance to Sun in meters."""
         pos = self.position.data
         frame = self.frame
 

--- a/solarwindpy/core/tensor.py
+++ b/solarwindpy/core/tensor.py
@@ -4,8 +4,6 @@
 import pandas as pd
 from typing import Union
 
-pd.set_option('mode.chained_assignment', 'raise')
-
 try:
     from . import base
 except ImportError:
@@ -20,6 +18,7 @@ class Tensor(base.Base):
     Attributes:
         _data (pd.DataFrame): The underlying tensor data.
     """
+
     def __init__(self, data: pd.DataFrame):
         """Initialize the Tensor object.
 
@@ -66,10 +65,10 @@ class Tensor(base.Base):
         Raises:
             ValueError: If the data does not contain the required columns.
         """
-        required_columns = pd.Index(['per', 'par', 'scalar'])
+        required_columns = pd.Index(["per", "par", "scalar"])
         if not required_columns.isin(data.columns).all():
             missing_columns = required_columns[~required_columns.isin(data.columns)]
-            raise ValueError(f'Missing required columns: {missing_columns.tolist()}')
+            raise ValueError(f"Missing required columns: {missing_columns.tolist()}")
 
     # @property
     # def per(self) -> Union[pd.Series, pd.DataFrame]:
@@ -89,4 +88,6 @@ class Tensor(base.Base):
     @property
     def magnitude(self) -> Union[pd.Series, pd.DataFrame]:
         """Calculate and return the magnitude of the tensor."""
-        return self.data.multiply({"par": 1/3, "per": 2/3}, axis=1, level="C").sum(axis=1)
+        return self.data.multiply({"par": 1 / 3, "per": 2 / 3}, axis=1, level="C").sum(
+            axis=1
+        )

--- a/solarwindpy/core/units_constants.py
+++ b/solarwindpy/core/units_constants.py
@@ -13,7 +13,6 @@ from scipy.constants import physical_constants
 # We rely on views via DataFrame.xs to reduce memory size and do not
 # `.copy(deep=True)`, so we want to make sure that this doesn't
 # accidentally cause a problem.
-pd.set_option("mode.chained_assignment", "raise")
 
 _misc_constants = {
     "e0": constants.epsilon_0,
@@ -122,8 +121,7 @@ class Constants(object):
 
     @property
     def m_amu(self):
-        r"""Masses in amu.
-        """
+        r"""Masses in amu."""
         return pd.Series(_m_amu)
 
     @property

--- a/solarwindpy/core/vector.py
+++ b/solarwindpy/core/vector.py
@@ -9,8 +9,6 @@ from typing import Union
 import numpy as np
 import pandas as pd
 
-pd.set_option("mode.chained_assignment", "raise")
-
 try:
     from . import base
 except ImportError:
@@ -56,8 +54,13 @@ class Vector(base.Base):
         """
         super().set_data(new)
         required_columns = pd.Index(["x", "y", "z"])
-        if not isinstance(new.columns, pd.MultiIndex) and not required_columns.isin(new.columns).all():
-            raise ValueError(f"Required columns: {required_columns}\nProvided: {new.columns}")
+        if (
+            not isinstance(new.columns, pd.MultiIndex)
+            and not required_columns.isin(new.columns).all()
+        ):
+            raise ValueError(
+                f"Required columns: {required_columns}\nProvided: {new.columns}"
+            )
         self._data = new
 
     # @property
@@ -195,7 +198,9 @@ class Vector(base.Base):
         # elif isinstance(other, pd.DataFrame):
         #     other = Vector(other).uv.data
         else:
-            raise NotImplementedError(f"Project method not implemented for {type(other)}")
+            raise NotImplementedError(
+                f"Project method not implemented for {type(other)}"
+            )
 
         # TODO: Verify math for projection with new other definition
         cart = self.cartesian
@@ -225,7 +230,9 @@ class Vector(base.Base):
         # elif isinstance(other, pd.DataFrame):
         #     other = Vector(other).uv.data
         else:
-            raise NotImplementedError(f"cos_theta method not implemented for {type(other)}")
+            raise NotImplementedError(
+                f"cos_theta method not implemented for {type(other)}"
+            )
 
         return self.uv.data.multiply(other, axis=1).sum(axis=1)
 
@@ -249,7 +256,7 @@ class BField(Vector):
             p_B = \frac{1}{2\mu_0} B^2
         """
         bsq = self.mag.pow(2.0)
-        const = self.units.b ** 2.0 / (2.0 * self.constants.misc.mu0 * self.units.pth)
+        const = self.units.b**2.0 / (2.0 * self.constants.misc.mu0 * self.units.pth)
         pb = bsq * const
         pb.name = "pb"
         return pb


### PR DESCRIPTION
## Summary
- configure pandas once in `solarwindpy/__init__.py`
- drop duplicate pandas configuration from core modules

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880622d5c90832cb1190e019a26f090