### PR TITLE
Refactor spacecraft tests to pytest style

### DIFF
--- a/solarwindpy/tests/conftest.py
+++ b/solarwindpy/tests/conftest.py
@@ -1,0 +1,51 @@
+import pandas as pd
+import numpy as np
+import pytest
+
+from solarwindpy import plasma
+from solarwindpy.tests import test_base as base
+
+
+@pytest.fixture(scope="session")
+def plasma_data():
+    return base.TestData().plasma_data.sort_index(axis=1)
+
+
+@pytest.fixture(scope="session")
+def spacecraft_data():
+    return base.TestData().spacecraft_data
+
+
+@pytest.fixture
+def prepared_plasma(request, plasma_data):
+    species = request.param
+    plas = plasma.Plasma(plasma_data, *species.split("+"))
+    par = plasma_data.w.par.pow(2)
+    per = plasma_data.w.per.pow(2)
+    scalar = ((2.0 * per) + par).multiply(1 / 3.0).pipe(np.sqrt)
+    cols = scalar.columns.to_series().apply(lambda x: ("w", "scalar", x))
+    scalar.columns = pd.MultiIndex.from_tuples(cols, names=["M", "C", "S"])
+    data = pd.concat([plasma_data, scalar], axis=1, sort=True)
+    return plas, data
+
+
+@pytest.fixture(autouse=True)
+def plasma_setup(request, plasma_data):
+    """Automatically prepare Plasma objects for test classes."""
+    cls = getattr(request, "cls", None)
+    if cls is None or not hasattr(cls, "species"):
+        return
+    species_attr = getattr(cls, "species")
+    if isinstance(species_attr, property):
+        species = species_attr.fget(cls())
+    else:
+        species = species_attr
+    plas = plasma.Plasma(plasma_data, *species.split("+"))
+    par = plasma_data.w.par.pow(2)
+    per = plasma_data.w.per.pow(2)
+    scalar = ((2.0 * per) + par).multiply(1 / 3.0).pipe(np.sqrt)
+    cols = scalar.columns.to_series().apply(lambda x: ("w", "scalar", x))
+    scalar.columns = pd.MultiIndex.from_tuples(cols, names=["M", "C", "S"])
+    data = pd.concat([plasma_data, scalar], axis=1, sort=True)
+    cls.object_testing = plas
+    cls.data = data

--- a/solarwindpy/tests/test_base.py
+++ b/solarwindpy/tests/test_base.py
@@ -5,7 +5,7 @@ Tests for basic synthetic data setup.
 import numpy as np
 import pandas as pd
 from pathlib import Path
-from unittest import TestCase
+
 
 pd.set_option("mode.chained_assignment", "raise")
 
@@ -64,12 +64,11 @@ class TestData(object):
         self._plasma_data = test_plasma
 
 
-class SWEData(TestCase):
+class SWEData:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         data = TestData()
         cls.data = data.plasma_data.sort_index(axis=1)
-        cls.set_object_testing()
 
 
 class AlphaTest(object):

--- a/solarwindpy/tests/test_plasma.py
+++ b/solarwindpy/tests/test_plasma.py
@@ -26,23 +26,7 @@ pd.set_option("mode.chained_assignment", "raise")
 
 
 class PlasmaTestBase(ABC):
-    @classmethod
-    def set_object_testing(cls):
-        # print(cls.__class__, "set_object_testing", flush=True)
-        # print("Data", cls.data, sep="\n")
-        data = cls.data
-        plas = plasma.Plasma(data, *cls().species.split("+"))
-
-        par = data.w.par.pow(2)
-        per = data.w.per.pow(2)
-        scalar = ((2.0 * per) + par).multiply(1.0 / 3.0).pipe(np.sqrt)
-        cols = scalar.columns.to_series().apply(lambda x: ("w", "scalar", x))
-        scalar.columns = pd.MultiIndex.from_tuples(cols, names=["M", "C", "S"])
-        data = pd.concat([data, scalar], axis=1, sort=True)
-
-        cls.object_testing = plas
-        cls.data = data
-        # print("Done with", cls.__class__, flush=True)
+    pass
 
     @abstractproperty
     def species(self):
@@ -1375,7 +1359,6 @@ class PlasmaTestBase(ABC):
                 ot.nc(sa, sb)
 
     def test_nc_with_spacecraft(self):
-
         if len(self.stuple) == 1:
             # We only test plasmas w/ > 1 species.
             return None
@@ -1457,7 +1440,6 @@ class PlasmaTestBase(ABC):
             sa, sb = combo
 
             for sc, tau_exp in zip((Wind, PSP), (tau_exp_Wind, tau_exp_PSP)):
-
                 ot.set_spacecraft(sc)
 
                 nuab = ot.nuc(sa, sb, both_species=False)
@@ -1527,7 +1509,6 @@ class PlasmaTestBase(ABC):
                 self.object_testing.estimate_electrons()
 
         else:
-
             qi = self.charge_states
             ni = self.data.n.xs("", axis=1, level="C").loc[:, list(stuple)]
             niqi = ni.multiply(qi, axis=1, level="S")
@@ -1677,7 +1658,6 @@ class PlasmaTestBase(ABC):
 
         ot = self.object_testing
         for combo in self.species_combinations:
-
             if len(combo) == 1:
                 msg = "Must have >1 species to calculate dynamic pressure."
                 with self.assertRaisesRegex(ValueError, msg):
@@ -1777,7 +1757,6 @@ class PlasmaTestBase(ABC):
                 ot.pdynamic(",".join(combo), scom)
 
     def test_pdynamic_with_m2q_projection(self):
-
         slist = list(self.stuple)
 
         if len(slist) == 1:
@@ -2044,7 +2023,6 @@ class PlasmaTestBase(ABC):
             self.assertEqual(alf_turb, built)
 
         elif ns == 2:
-
             # Check CoM velocity case.
             vcom = (
                 v.multiply(r, axis=1, level="S")
@@ -2101,7 +2079,6 @@ class PlasmaTestBase(ABC):
             self.assertEqual(alf_turb, built)
 
         elif ns == 3:
-
             # Check CoM velocity case.
             vcom = (
                 v.multiply(r, axis=1, level="S")

--- a/solarwindpy/tests/test_spacecraft.py
+++ b/solarwindpy/tests/test_spacecraft.py
@@ -6,8 +6,8 @@ import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 from scipy import constants
-from unittest import TestCase
-from abc import ABC, abstractclassmethod, abstractproperty
+import pytest
+from abc import ABC, abstractmethod, abstractproperty
 
 # import test_base as base
 from solarwindpy.tests import test_base as base
@@ -20,7 +20,7 @@ pd.set_option("mode.chained_assignment", "raise")
 
 class TestBase(ABC):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         data = base.TestData()
         #         pdb.set_trace()
         cls.data = data.spacecraft_data
@@ -56,7 +56,8 @@ class TestBase(ABC):
     #         del cls.spacecraft_data
     #         cls.set_object_testing()
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def set_object_testing(cls):
         pass
 
@@ -72,17 +73,17 @@ class TestBase(ABC):
         cols = pd.Index(("x", "y", "z"), name="C")
         ot = self.object_testing
         pdt.assert_index_equal(cols, ot.position.data.columns)
-        self.assertIsInstance(ot.position, vector.Vector)
-        self.assertEqual(ot.position, ot.r)
-        self.assertEqual(ot.position, ot.pos)
+        assert isinstance(ot.position, vector.Vector)
+        assert ot.position == ot.r
+        assert ot.position == ot.pos
         return ot
 
     def test_velocity(self):
         cols = pd.Index(("x", "y", "z"), name="C")
         ot = self.object_testing
         pdt.assert_index_equal(cols, ot.velocity.data.columns)
-        self.assertIsInstance(ot.velocity, vector.Vector)
-        self.assertEqual(ot.velocity, ot.v)
+        assert isinstance(ot.velocity, vector.Vector)
+        assert ot.velocity == ot.v
         return ot
 
     def test_data(self):
@@ -91,11 +92,11 @@ class TestBase(ABC):
 
     def test_name(self):
         ot = self.object_testing
-        self.assertEqual(self.name, ot.name)
+        assert self.name == ot.name
 
     def test_frame(self):
         ot = self.object_testing
-        self.assertEqual(self.frame, ot.frame)
+        assert self.frame == ot.frame
 
     def test_distance2sun(self):
         ot = self.object_testing
@@ -129,7 +130,7 @@ class TestBase(ABC):
         pdt.assert_series_equal(dist, ot.distance2sun)
 
 
-class TestWind(TestBase, TestCase):
+class TestWind(TestBase):
     @classmethod
     def set_object_testing(cls):
         data = cls.data.xs("gse", axis=1, level="M")
@@ -156,17 +157,17 @@ class TestWind(TestBase, TestCase):
         pdt.assert_frame_equal(pos, ot.position.data)
 
     def test_velocity(self):
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             self.object_testing.velocity
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             self.object_testing.v
 
     def test_carrington(self):
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             self.object_testing.carrington
 
 
-class TestPSP(TestBase, TestCase):
+class TestPSP(TestBase):
     @classmethod
     def set_object_testing(cls):
         p = cls.data.xs("pos_HCI", axis=1, level="M")
@@ -207,6 +208,6 @@ class TestPSP(TestBase, TestCase):
         carr = self.data.xs("carr", axis=1, level="M")
 
         ot = self.object_testing
-        self.assertIsInstance(ot.carrington, pd.DataFrame)
+        assert isinstance(ot.carrington, pd.DataFrame)
         pdt.assert_index_equal(cols, ot.carrington.columns)
         pdt.assert_frame_equal(carr, ot.carrington)


### PR DESCRIPTION
## Summary
- add pytest fixtures for plasma setup
- update spacecraft tests to use pytest assertions
- drop `unittest.TestCase` usage in base testing utilities
- stub out unused `set_object_testing` in plasma tests

## Testing
- `pytest solarwindpy/tests/test_spacecraft.py::TestWind::test_position -q`
- `pytest solarwindpy/tests/test_spacecraft.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881c38df71c832cb811466cbc59cb57