### PR TITLE
Use pytest fixtures for SWEData

### DIFF
--- a/solarwindpy/tests/conftest.py
+++ b/solarwindpy/tests/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+from solarwindpy.tests import test_base as base
+
+
+@pytest.fixture(scope="module")
+def swe_data_values():
+    data = base.TestData()
+    plasma = data.plasma_data.sort_index(axis=1)
+    spacecraft = data.spacecraft_data
+    return plasma, spacecraft
+
+
+@pytest.fixture(scope="module")
+def plasma_data(swe_data_values):
+    return swe_data_values[0]
+
+
+@pytest.fixture(scope="module")
+def spacecraft_data(swe_data_values):
+    return swe_data_values[1]
+
+
+@pytest.fixture(scope="class")
+def swe_data(request, plasma_data, spacecraft_data):
+    cls = request.cls
+    cls.data = plasma_data
+    cls.spacecraft_data = spacecraft_data
+    if hasattr(cls, "set_object_testing"):
+        cls.set_object_testing()
+    yield

--- a/solarwindpy/tests/test_alfvenic_turbulence.py
+++ b/solarwindpy/tests/test_alfvenic_turbulence.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pandas.testing as pdt
 
 from abc import ABC, abstractproperty
+from unittest import TestCase
 
 from scipy import constants
 from scipy.constants import physical_constants
@@ -22,7 +23,7 @@ from solarwindpy import alfvenic_turbulence as turb
 pd.set_option("mode.chained_assignment", "raise")
 
 
-class AlfvenicTrubulenceTestBase(ABC):
+class AlfvenicTrubulenceTestBase(ABC, TestCase):
     #    def setUp(self):
     #        self.object_testing.set_agg("mean")
     #        self.object_testing.update_rolling(window=2,

--- a/solarwindpy/tests/test_base.py
+++ b/solarwindpy/tests/test_base.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 from unittest import TestCase
+import pytest
 
 pd.set_option("mode.chained_assignment", "raise")
 
@@ -64,12 +65,11 @@ class TestData(object):
         self._plasma_data = test_plasma
 
 
-class SWEData(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        data = TestData()
-        cls.data = data.plasma_data.sort_index(axis=1)
-        cls.set_object_testing()
+@pytest.mark.usefixtures("swe_data")
+class SWEData:
+    """Mixin providing plasma data for test classes."""
+
+    pass
 
 
 class AlphaTest(object):

--- a/solarwindpy/tests/test_ions.py
+++ b/solarwindpy/tests/test_ions.py
@@ -15,6 +15,7 @@ import pandas as pd
 import pandas.testing as pdt
 
 from abc import ABC, abstractproperty
+from unittest import TestCase
 
 # from abc import abstractmethod, abstractstaticmethod, abstractclassmethod
 # from unittest import TestCase
@@ -35,7 +36,7 @@ from solarwindpy import ions
 pd.set_option("mode.chained_assignment", "raise")
 
 
-class IonTestBase(ABC):
+class IonTestBase(ABC, TestCase):
     @classmethod
     def set_object_testing(cls):
         # print(cls.__class__, "set_object_testing", flush=True)
@@ -195,7 +196,7 @@ class TestIonP2(base.P2Test, IonTestBase, base.SWEData):
     pass
 
 
-class TestIonSpecificsOptions(base.TestData):
+class TestIonSpecificsOptions(TestCase):
     @classmethod
     def setUpClass(cls):
         r"""
@@ -203,10 +204,8 @@ class TestIonSpecificsOptions(base.TestData):
         doesn't rely on `object_testing`.
         """
         # print("SWEData.setUpClass", flush=True)
-        super(TestIonSpecificsOptions, cls).setUpClass()
-        # print(cls.data.iloc[:, :7])
-        # print(cls.data.columns.values)
-        cls.data = cls.data.xs("", axis=1, level="N")
+        data = base.TestData().plasma_data
+        cls.data = data.xs("", axis=1, level="N")
 
     #     def test_init_with_species(self):
     #         species = "a"

--- a/solarwindpy/tests/test_plasma.py
+++ b/solarwindpy/tests/test_plasma.py
@@ -9,6 +9,7 @@ import itertools
 import pandas.testing as pdt
 
 from abc import ABC, abstractproperty, abstractmethod
+from unittest import TestCase
 
 from scipy import constants
 from scipy.constants import physical_constants
@@ -25,7 +26,7 @@ from solarwindpy import alfvenic_turbulence
 pd.set_option("mode.chained_assignment", "raise")
 
 
-class PlasmaTestBase(ABC):
+class PlasmaTestBase(ABC, TestCase):
     @classmethod
     def set_object_testing(cls):
         # print(cls.__class__, "set_object_testing", flush=True)

--- a/solarwindpy/tests/test_quantities.py
+++ b/solarwindpy/tests/test_quantities.py
@@ -20,7 +20,7 @@ from solarwindpy import tensor
 pd.set_option("mode.chained_assignment", "raise")
 
 
-class QuantityTestBase(ABC):
+class QuantityTestBase(ABC, TestCase):
     def test_data(self):
         data = self.data
         if isinstance(data, pd.Series):

--- a/solarwindpy/tests/test_spacecraft.py
+++ b/solarwindpy/tests/test_spacecraft.py
@@ -18,7 +18,7 @@ from solarwindpy import spacecraft
 pd.set_option("mode.chained_assignment", "raise")
 
 
-class TestBase(ABC):
+class TestBase(ABC, TestCase):
     @classmethod
     def setUpClass(cls):
         data = base.TestData()


### PR DESCRIPTION
## Summary
- remove `TestCase` from `SWEData`
- add `swe_data` fixture for test classes
- expose `plasma_data` and `spacecraft_data` fixtures
- update base classes to inherit from `TestCase`
- adjust ion test options to avoid mixin conflicts

## Testing
- `black solarwindpy/tests/test_ions.py solarwindpy/tests/test_base.py solarwindpy/tests/conftest.py solarwindpy/tests/test_plasma.py solarwindpy/tests/test_alfvenic_turbulence.py solarwindpy/tests/test_quantities.py solarwindpy/tests/test_spacecraft.py`
- `pytest -q` *(fails: 23 failed, 436 passed, 81 skipped, 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6881c389ae04832caa12f11f0755a27d