### PR TITLE
Fix W605 by using raw string for units docstring

### DIFF
--- a/solarwindpy/core/units_constants.py
+++ b/solarwindpy/core/units_constants.py
@@ -137,7 +137,7 @@ class Constants:
 
 @dataclass
 class Units:
-    """Common unit conversion factors.
+    r"""Common unit conversion factors.
 
     Attributes
     ----------


### PR DESCRIPTION
## Summary
- add a raw string prefix to a docstring in `Units` dataclass
- run tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881aa0ab9c8832c8f2c50ec0f025a81