### PR TITLE
Add datetime label tests

### DIFF
--- a/solarwindpy/tests/plotting/labels/test_datetime.py
+++ b/solarwindpy/tests/plotting/labels/test_datetime.py
@@ -1,0 +1,74 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def datetime_mod():
+    """Load datetime label module without importing :mod:`solarwindpy`.
+
+    Returns
+    -------
+    module
+        The loaded ``datetime`` module.
+    """
+    root = Path(__file__).resolve().parents[3] / "plotting" / "labels"
+
+    pkg = types.ModuleType("solarwindpy")
+    plotting = types.ModuleType("solarwindpy.plotting")
+    labels_pkg = types.ModuleType("solarwindpy.plotting.labels")
+    pkg.plotting = plotting
+    plotting.labels = labels_pkg
+    sys.modules["solarwindpy"] = pkg
+    sys.modules["solarwindpy.plotting"] = plotting
+    sys.modules["solarwindpy.plotting.labels"] = labels_pkg
+
+    def load(name, filename):
+        spec = importlib.util.spec_from_file_location(name, root / filename)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    labels_pkg.base = load("solarwindpy.plotting.labels.base", "base.py")
+    labels_pkg.special = load("solarwindpy.plotting.labels.special", "special.py")
+    dt_mod = load("solarwindpy.plotting.labels.datetime", "datetime.py")
+    return dt_mod
+
+
+def test_timedelta_latex_and_path(datetime_mod):
+    """Verify ``Timedelta`` LaTeX and path string."""
+    td = datetime_mod.Timedelta("2h")
+    assert str(td.path) == "dt-2h"
+    assert str(td) == "$\\Delta t \\; [2 \\; \\mathrm{h}]$"
+
+
+def test_datetime_label(datetime_mod):
+    """Verify ``DateTime`` label formatting."""
+    dt = datetime_mod.DateTime("Day of Year")
+    assert str(dt.path) == "day-of-year"
+    assert str(dt) == "$\\mathrm{Day \\; of \\; Year}$"
+
+
+def test_epoch_label(datetime_mod):
+    """Verify ``Epoch`` label formatting."""
+    epoch = datetime_mod.Epoch("Hour", "Day")
+    assert str(epoch.path) == "Hour-of-Day"
+    assert str(epoch) == "$\\mathrm{Hour \\, of \\, Day}$"
+
+
+def test_frequency_label(datetime_mod):
+    """Validate ``Frequency`` label output."""
+    freq = datetime_mod.Frequency("1h")
+    assert str(freq.path) == "frequency_of_(1 \\; \\mathrm{h})^-1"
+    assert str(freq) == "$\\mathrm{Frequency} \\; [(1 \\; \\mathrm{h})^-1]$"
+
+
+def test_january1st_label(datetime_mod):
+    """Validate ``January1st`` label output."""
+    jan = datetime_mod.January1st()
+    assert str(jan.path) == "January-1st-of-Year"
+    assert str(jan) == "$\\mathrm{January \\; 1^{st} \\; of \\; Year}$"


### PR DESCRIPTION
## Summary
- add tests for special datetime labels

## Testing
- `flake8 solarwindpy/tests/plotting/labels/test_datetime.py`
- `python - <<'EOF'
import sys, types
import pytest
stub = types.ModuleType('solarwindpy'); stub.tests = types.ModuleType('solarwindpy.tests'); stub.tests.plotting=types.ModuleType('solarwindpy.tests.plotting'); stub.tests.plotting.labels=types.ModuleType('solarwindpy.tests.plotting.labels');
sys.modules['solarwindpy']=stub; sys.modules['solarwindpy.tests']=stub.tests; sys.modules['solarwindpy.tests.plotting']=stub.tests.plotting; sys.modules['solarwindpy.tests.plotting.labels']=stub.tests.plotting.labels;
ret = pytest.main(['solarwindpy/tests/plotting/labels/test_datetime.py', '-q']); print('exit', ret)
EOF

------
https://chatgpt.com/codex/tasks/task_e_6881b4c63100832c9175b4dad1182eae