### PR TITLE
Combine tests from label-related PRs

### DIFF
--- a/solarwindpy/tests/conftest.py
+++ b/solarwindpy/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+import types
+from pathlib import Path
+
+pkg_path = Path(__file__).resolve().parent.parent
+package = types.ModuleType("solarwindpy")
+package.__path__ = [str(pkg_path)]
+sys.modules.setdefault("solarwindpy", package)

--- a/solarwindpy/tests/plotting/labels/test_composition.py
+++ b/solarwindpy/tests/plotting/labels/test_composition.py
@@ -1,0 +1,64 @@
+import logging
+import pytest
+
+from solarwindpy.plotting.labels import composition
+
+
+class IonWithUnits(composition.Ion):
+    """Ion subclass that allows overriding units."""
+
+    def __init__(self, species, charge, units):
+        super().__init__(species, charge)
+        self._units_override = units
+
+    @property
+    def units(self):
+        return self._units_override
+
+
+def test_set_species_charge_known_species(caplog):
+    """Check that a known species does not trigger a warning.
+
+    Parameters
+    ----------
+    caplog : pytest.LogCaptureFixture
+        Logging capture fixture.
+    """
+    with caplog.at_level(logging.WARNING):
+        ion = composition.Ion("Fe", "2")
+    assert ion.species == "Fe"
+    assert ion.charge == "2"
+    assert "Unknown species" not in caplog.text
+
+
+def test_set_species_charge_unknown_species(caplog):
+    """Check that an unknown species logs a warning.
+
+    Parameters
+    ----------
+    caplog : pytest.LogCaptureFixture
+        Logging capture fixture.
+    """
+    with caplog.at_level(logging.WARNING):
+        composition.Ion("Xe", "2")
+    assert "Unknown species (Xe)" in caplog.text
+
+
+def test_set_species_charge_invalid_charge():
+    """Ensure invalid charge raises ``ValueError``."""
+    with pytest.raises(ValueError):
+        composition.Ion("Fe", "a")
+
+
+def test_charge_state_units_equal():
+    """``ChargeState`` has ``#`` units when ion units match."""
+    cs = composition.ChargeState(("O", "2"), ("Fe", "3"))
+    assert cs.units == r"\#"
+
+
+def test_charge_state_units_different():
+    """``ChargeState`` units combine when ion units differ."""
+    ion_a = IonWithUnits("O", "2", "cm-3")
+    ion_b = IonWithUnits("Fe", "3", "km/s")
+    cs = composition.ChargeState(ion_a, ion_b)
+    assert cs.units == "cm-3/km/s"

--- a/solarwindpy/tests/plotting/labels/test_datetime.py
+++ b/solarwindpy/tests/plotting/labels/test_datetime.py
@@ -1,0 +1,74 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def datetime_mod():
+    """Load datetime label module without importing :mod:`solarwindpy`.
+
+    Returns
+    -------
+    module
+        The loaded ``datetime`` module.
+    """
+    root = Path(__file__).resolve().parents[3] / "plotting" / "labels"
+
+    pkg = types.ModuleType("solarwindpy")
+    plotting = types.ModuleType("solarwindpy.plotting")
+    labels_pkg = types.ModuleType("solarwindpy.plotting.labels")
+    pkg.plotting = plotting
+    plotting.labels = labels_pkg
+    sys.modules["solarwindpy"] = pkg
+    sys.modules["solarwindpy.plotting"] = plotting
+    sys.modules["solarwindpy.plotting.labels"] = labels_pkg
+
+    def load(name, filename):
+        spec = importlib.util.spec_from_file_location(name, root / filename)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    labels_pkg.base = load("solarwindpy.plotting.labels.base", "base.py")
+    labels_pkg.special = load("solarwindpy.plotting.labels.special", "special.py")
+    dt_mod = load("solarwindpy.plotting.labels.datetime", "datetime.py")
+    return dt_mod
+
+
+def test_timedelta_latex_and_path(datetime_mod):
+    """Verify ``Timedelta`` LaTeX and path string."""
+    td = datetime_mod.Timedelta("2h")
+    assert str(td.path) == "dt-2h"
+    assert str(td) == "$\\Delta t \\; [2 \\; \\mathrm{h}]$"
+
+
+def test_datetime_label(datetime_mod):
+    """Verify ``DateTime`` label formatting."""
+    dt = datetime_mod.DateTime("Day of Year")
+    assert str(dt.path) == "day-of-year"
+    assert str(dt) == "$\\mathrm{Day \\; of \\; Year}$"
+
+
+def test_epoch_label(datetime_mod):
+    """Verify ``Epoch`` label formatting."""
+    epoch = datetime_mod.Epoch("Hour", "Day")
+    assert str(epoch.path) == "Hour-of-Day"
+    assert str(epoch) == "$\\mathrm{Hour \\, of \\, Day}$"
+
+
+def test_frequency_label(datetime_mod):
+    """Validate ``Frequency`` label output."""
+    freq = datetime_mod.Frequency("1h")
+    assert str(freq.path) == "frequency_of_(1 \\; \\mathrm{h})^-1"
+    assert str(freq) == "$\\mathrm{Frequency} \\; [(1 \\; \\mathrm{h})^-1]$"
+
+
+def test_january1st_label(datetime_mod):
+    """Validate ``January1st`` label output."""
+    jan = datetime_mod.January1st()
+    assert str(jan.path) == "January-1st-of-Year"
+    assert str(jan) == "$\\mathrm{January \\; 1^{st} \\; of \\; Year}$"

--- a/solarwindpy/tests/plotting/labels/test_init.py
+++ b/solarwindpy/tests/plotting/labels/test_init.py
@@ -1,0 +1,64 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_labels_module():
+    """Load the labels module without importing the full package."""
+    pkg_root = Path(__file__).resolve().parents[3] / "plotting" / "labels"
+    root_pkg = types.ModuleType("swlabels")
+    root_pkg.__path__ = [str(pkg_root)]
+    sys.modules["swlabels"] = root_pkg
+
+    for name in (
+        "base",
+        "composition",
+        "chemistry",
+        "datetime",
+        "elemental_abundance",
+        "special",
+    ):
+        spec = importlib.util.spec_from_file_location(
+            f"swlabels.{name}", pkg_root / f"{name}.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        module.__package__ = "swlabels"
+        sys.modules[f"swlabels.{name}"] = module
+        spec.loader.exec_module(module)
+
+    spec = importlib.util.spec_from_file_location("swlabels", pkg_root / "__init__.py")
+    labels = importlib.util.module_from_spec(spec)
+    labels.__package__ = "swlabels"
+    sys.modules["swlabels"] = labels
+    spec.loader.exec_module(labels)
+    return labels
+
+
+def test_clean_str_list_for_printing():
+    """Test grouping produced by ``_clean_str_list_for_printing``."""
+    labels = _load_labels_module()
+    data = ["beta", "alpha", "gamma", "Charlie"]
+    result = labels._clean_str_list_for_printing(data)
+    assert result.splitlines() == ["Charlie", "alpha", "beta", "gamma"]
+
+
+def test_available_labels_output(capsys):
+    """Check that ``available_labels`` prints all major sections.
+
+    Parameters
+    ----------
+    capsys : pytest.CaptureFixture
+        Pytest fixture used to capture standard output.
+    """
+    labels = _load_labels_module()
+    labels.available_labels()
+    captured = capsys.readouterr().out
+    for section in (
+        "TeXlabel knows",
+        "Measurements",
+        "Components",
+        "Species",
+        "Special",
+    ):
+        assert section in captured


### PR DESCRIPTION
## Summary
- port tests from PRs 58, 65, and 68

## Testing
- `pytest -q`
- `flake8` *(fails: invalid escape sequence warnings in unmodified files)*

------
https://chatgpt.com/codex/tasks/task_e_6882a876a690832c89b0d3bc73a8acd5