### PR TITLE
Switch docs to conda env and add generator script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,13 +22,20 @@ Development
 -----------
 
 1. Fork the repository and clone your fork.
-2. Create a virtual environment and install the development requirements:
+2. Create a Conda environment using the provided YAML file:
 
    .. code-block:: bash
 
-      python -m venv .venv
-      source .venv/bin/activate
-      pip install -r requirements-dev.txt
+      conda env create -f solarwindpy-20250403.yml
+      conda activate solarwindpy-20250403
+
+   Alternatively generate the environment from ``requirements-dev.txt``:
+
+   .. code-block:: bash
+
+      python scripts/requirements_to_conda_env.py --name solarwindpy-dev
+      conda env create -f environment.yml
+      conda activate solarwindpy-dev
 
 3. Run the test suite with ``pytest``:
 

--- a/scripts/requirements_to_conda_env.py
+++ b/scripts/requirements_to_conda_env.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+"""Generate a Conda environment file from a requirements list.
+
+This script reads ``requirements.txt`` or a user-specified file and
+produces an ``environment.yml`` suitable for ``conda env create``.
+
+Examples
+--------
+Run with the default requirements file::
+
+    python scripts/requirements_to_conda_env.py
+
+Specify a different requirements file and environment name::
+
+    python scripts/requirements_to_conda_env.py custom.txt --name my-env
+"""
+
+from __future__ import annotations
+
+import argparse
+import yaml
+
+
+def generate_environment(req_path: str, env_name: str) -> None:
+    """Create ``environment.yml`` from a requirements file.
+
+    Parameters
+    ----------
+    req_path : str
+        Path to the requirements file.
+    env_name : str
+        Name of the Conda environment.
+    """
+    with open(req_path) as req_file:
+        packages = [
+            line.strip()
+            for line in req_file
+            if line.strip() and not line.startswith("#")
+        ]
+
+    env = {
+        "name": env_name,
+        "channels": ["conda-forge", "defaults"],
+        "dependencies": packages,
+    }
+
+    with open("environment.yml", "w") as out_file:
+        yaml.safe_dump(env, out_file, sort_keys=False)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "requirements",
+        nargs="?",
+        default="requirements-dev.txt",
+        help="Path to the requirements file.",
+    )
+    parser.add_argument(
+        "--name",
+        default="solarwindpy-dev",
+        help="Name of the Conda environment.",
+    )
+    args = parser.parse_args()
+
+    generate_environment(args.requirements, args.name)
+
+
+if __name__ == "__main__":
+    main()

--- a/solarwindpy/core/units_constants.py
+++ b/solarwindpy/core/units_constants.py
@@ -137,7 +137,7 @@ class Constants:
 
 @dataclass
 class Units:
-    """Common unit conversion factors.
+    r"""Common unit conversion factors.
 
     Attributes
     ----------

--- a/solarwindpy/tests/plotting/labels/test_datetime.py
+++ b/solarwindpy/tests/plotting/labels/test_datetime.py
@@ -42,8 +42,8 @@ def datetime_mod():
 def test_timedelta_latex_and_path(datetime_mod):
     """Verify ``Timedelta`` LaTeX and path string."""
     td = datetime_mod.Timedelta("2h")
-    assert str(td.path) == "dt-2H"
-    assert str(td) == "$\\Delta t \\; [2 \\; \\mathrm{H}]$"
+    assert str(td.path) == "dt-2h"
+    assert str(td) == "$\\Delta t \\; [2 \\; \\mathrm{h}]$"
 
 
 def test_datetime_label(datetime_mod):
@@ -63,8 +63,8 @@ def test_epoch_label(datetime_mod):
 def test_frequency_label(datetime_mod):
     """Validate ``Frequency`` label output."""
     freq = datetime_mod.Frequency("1h")
-    assert str(freq.path) == "frequency_of_(1 \\; \\mathrm{H})^-1"
-    assert str(freq) == "$\\mathrm{Frequency} \\; [(1 \\; \\mathrm{H})^-1]$"
+    assert str(freq.path) == "frequency_of_(1 \\; \\mathrm{h})^-1"
+    assert str(freq) == "$\\mathrm{Frequency} \\; [(1 \\; \\mathrm{h})^-1]$"
 
 
 def test_january1st_label(datetime_mod):


### PR DESCRIPTION
## Summary
- provide script to generate `environment.yml` from a requirements file
- document conda-based setup instructions
- fix failing datetime label tests for new pandas
- silence flake8 warning by raw string docstring

## Testing
- `pip install -r requirements-dev.txt`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68831a706528832cacc8d2cb60507b6a