### PR TITLE
Add tasks for skipped plasma tests

### DIFF
--- a/tasks/fix_test_afsq.md
+++ b/tasks/fix_test_afsq.md
@@ -1,0 +1,12 @@
+# Fix test_afsq
+
+Assigned to: blalterman
+
+`test_afsq` fails with `KeyError: "['scalar'] not found in axis"` when the skip marker is removed. The test covers the `Plasma.afsq` calculation. Diagnose how the method builds its DataFrame and ensure the `scalar` column is handled properly.
+
+Steps:
+1. Unskip `test_afsq` in `tests/test_plasma.py`.
+2. Run the test to view the failure.
+3. Review `Plasma.afsq` to check which columns are selected and dropped.
+4. Update the method or test to consistently manage the `scalar` column.
+5. Run the full test suite to confirm the fix.

--- a/tasks/fix_test_anisotropy.md
+++ b/tasks/fix_test_anisotropy.md
@@ -1,0 +1,12 @@
+# Fix test_anisotropy
+
+Assigned to: blalterman
+
+When unskipped, `test_anisotropy` fails with `KeyError: "['scalar'] not found in axis"`. The test expects the `Plasma.anisotropy` method to drop or ignore the `scalar` component correctly. Investigate the DataFrame operations in this method and adjust either the implementation or the test expectations.
+
+Steps:
+1. Remove the skip decorator from `test_anisotropy`.
+2. Run the test to reproduce the KeyError.
+3. Examine how the `scalar` column is handled in `Plasma.anisotropy`.
+4. Modify the method or test to properly process all columns.
+5. Ensure the corrected test passes for single and multi-species cases.

--- a/tasks/fix_test_beta.md
+++ b/tasks/fix_test_beta.md
@@ -1,0 +1,12 @@
+# Fix test_beta
+
+Assigned to: blalterman
+
+The `test_beta` test is skipped due to DataFrame shape mismatches when computing plasma beta. Unskip the test and debug the `Plasma.beta` method to ensure it returns the expected structure for all species combinations.
+
+Steps:
+1. Remove the skip marker from `test_beta` in `tests/test_plasma.py`.
+2. Run the failing test to capture the mismatch.
+3. Inspect the calculation of magnetic and thermal pressures used for beta.
+4. Correct the implementation or adjust expectations in the test suite.
+5. Verify all tests pass after the fix.

--- a/tasks/fix_test_caani.md
+++ b/tasks/fix_test_caani.md
@@ -1,0 +1,12 @@
+# Fix test_caani
+
+Assigned to: blalterman
+
+Unskipping `test_caani` raises a `KeyError` for the `scalar` column. The test validates the combined Alfvén speed and anisotropy calculation. Debug how `Plasma.caani` generates its return values and ensure the `scalar` component is properly derived or excluded.
+
+Steps:
+1. Remove the skip decorator from `test_caani`.
+2. Run the test suite to observe the failure.
+3. Inspect the internals of `Plasma.caani`, especially the use of `Plasma.afsq`.
+4. Fix column handling or adjust the expected output in the test.
+5. Confirm the repaired code passes all tests.

--- a/tasks/fix_test_drop_species.md
+++ b/tasks/fix_test_drop_species.md
@@ -1,0 +1,12 @@
+# Fix test_drop_species
+
+Assigned to: blalterman
+
+`test_drop_species` is skipped with the comment "Not yet implemented". When temporarily unskipped, it fails with `AttributeError` or `NotImplementedError` depending on the class used. Implement dropping of individual species from a `Plasma` instance and update the test accordingly.
+
+Steps:
+1. Remove the skip decorator from `test_drop_species`.
+2. Run the test to see the current exceptions.
+3. Implement `Plasma.drop_species` so it removes selected species and returns an updated object.
+4. Adjust the tests to match the intended API and handle edge cases (e.g., empty plasma).
+5. Run all tests to verify the method works across species combinations.

--- a/tasks/fix_test_pth.md
+++ b/tasks/fix_test_pth.md
@@ -1,0 +1,12 @@
+# Fix test_pth
+
+Assigned to: blalterman
+
+The `test_pth` test is currently skipped because expected and actual DataFrames differ across several species. Unskip the test and investigate why `Plasma.pth` returns a DataFrame with mismatched shape. Update the implementation or test so that the data frames match.
+
+Steps:
+1. Remove the `@pytest.mark.skip` decorator from `test_pth` in `tests/test_plasma.py`.
+2. Run the test suite to reproduce the failure.
+3. Trace the computation of plasma thermal pressure in `Plasma.pth` for each species.
+4. Correct the implementation or adjust the expected result in the test.
+5. Add regression tests if needed and ensure all tests pass.

--- a/tasks/fix_test_specific_entropy.md
+++ b/tasks/fix_test_specific_entropy.md
@@ -1,0 +1,12 @@
+# Fix test_specific_entropy
+
+Assigned to: blalterman
+
+This test fails with `KeyError: 'scalar'` when the skip marker is removed. The issue arises while fetching the scalar component of plasma pressure in `Plasma.specific_entropy`. Determine whether the calculation should include a scalar column or use a different index.
+
+Steps:
+1. Unskip `test_specific_entropy` in `tests/test_plasma.py`.
+2. Run the test suite to reproduce the KeyError.
+3. Trace the calculation of thermal pressure and density within `Plasma.specific_entropy`.
+4. Add or adjust the `scalar` component as needed to satisfy the test expectations.
+5. Verify all updated tests pass.


### PR DESCRIPTION
## Summary
- document individual tasks for each skipped test in `test_plasma`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883ff877798832ca6f17cd7a5980c76