### PR TITLE
Fix DeprecationWarnings from invalid escape sequences

### DIFF
--- a/solarwindpy/fitfunctions/plots.py
+++ b/solarwindpy/fitfunctions/plots.py
@@ -394,8 +394,8 @@ class FFPlot(object):
             marker = kwargs.pop("marker", "P")
             linestyle = kwargs.pop("linestyle", "-")
 
-            label = " \; ".join([label, kind.title()]).lstrip(  # noqa: W605
-                " \; "  # noqa: W605
+            label = r" \; ".join([label, kind.title()]).lstrip(  # noqa: W605
+                r" \; "  # noqa: W605
             )
             label = r"$\mathrm{%s}$" % label
             #             label = (r"$\mathrm{%s \; %s}$" % (label, kind.title()).replace(" \; ", "")
@@ -420,7 +420,7 @@ class FFPlot(object):
                 self.observations.used.x,
                 self.residuals(pct=pct, robust=False),
                 label=(r"$\mathrm{%s \; Simple}$" % label).lstrip(  # noqa: W605
-                    " \; "  # noqa: W605
+                    r" \; "  # noqa: W605
                 ),
                 drawstyle=drawstyle,
                 color="forestgreen",
@@ -438,7 +438,7 @@ class FFPlot(object):
                     self.observations.used.x,
                     r,
                     label=(r"$\mathrm{%s \; Robust}$" % label).lstrip(  # noqa: W605
-                        " \; "  # noqa: W605
+                        r" \; "  # noqa: W605
                     ),
                     drawstyle=drawstyle,
                     color="darkorange",

--- a/solarwindpy/fitfunctions/tex_info.py
+++ b/solarwindpy/fitfunctions/tex_info.py
@@ -162,7 +162,7 @@ class TeXinfo(object):
         #         rel_err = [template.format(k, np.abs(v)) for k, v in TeX.items()]
 
         rel_err = tabulate(
-            [[f"{k} \;\;\; ", np.abs(v)] for k, v in TeX.items()],  # noqa: W605
+            [[f"{k} \\;\\;\\; ", np.abs(v)] for k, v in TeX.items()],  # noqa: W605
             floatfmt=".3e",
             tablefmt="plain",
         )

--- a/solarwindpy/fitfunctions/trend_fits.py
+++ b/solarwindpy/fitfunctions/trend_fits.py
@@ -190,7 +190,7 @@ class TrendFit(object):
 
         in_trend = y_ok & w_ok
 
-        legend_title = "${}={} \; {}$\n{}"  # noqa: W605
+        legend_title = r"${}={} \; {}$\n{}"  # noqa: W605
 
         #         xlbl = self.labels.x
         #         try:
@@ -234,7 +234,7 @@ class TrendFit(object):
 
         x = pd.IntervalIndex(popt.index).mid
         if self.trend_logx:
-            x = 10.0 ** x
+            x = 10.0**x
 
         if "weights" in kwargs:
             raise ValueError("Weights are handled by `wkey1d`")
@@ -266,7 +266,7 @@ class TrendFit(object):
 
         x = pd.IntervalIndex(popt.index).mid
         if self.trend_logx:
-            x = 10.0 ** x
+            x = 10.0**x
 
         color = kwargs.pop("color", "cyan")
         linestyle = kwargs.pop("ls", "--")

--- a/solarwindpy/plotting/labels/base.py
+++ b/solarwindpy/plotting/labels/base.py
@@ -148,7 +148,7 @@ _trans_units = {
     # Plasma measurements.
     "b": _inU["b"],
     "n": _inU["cm-3"],
-    "rho": "m_p \; " + _inU["cm-3"],  # noqa: W605
+    "rho": r"m_p \; " + _inU["cm-3"],  # noqa: W605
     "v": _inU["kms"],
     "w": _inU["kms"],
     "dv": _inU["kms"],
@@ -169,11 +169,11 @@ _trans_units = {
     "edv": _inU["dimless"],
     "S": r"\mathrm{eV \, cm^2 \, m_p^{-5/3}}",  # Specific Entropy
     # Flux
-    "flux": "10^{-9} \, %s \, s^{-1}" % _inU["cm-3"].replace("-3", "-2"),  # noqa: W605
+    "flux": r"10^{-9} \, %s \, s^{-1}" % _inU["cm-3"].replace("-3", "-2"),  # noqa: W605
     # Collisional things
     "lnlambda": _inU["dimless"],
     # TODO: verify that these units are Hertz.
-    "nuc": "10^{-7} \mathrm{Hz}",  # noqa: W605
+    "nuc": r"10^{-7} \mathrm{Hz}",  # noqa: W605
     "nc": _inU["dimless"],
     "chisq": _inU["dimless"],
     "chisqnu": _inU["dimless"],
@@ -532,8 +532,8 @@ class TeXlabel(Base):
 
         # clean up empty parentheses
         tex = (
-            tex.replace("\; ()", "")  # noqa: W605
-            .replace("\; {}", "")  # noqa: W605
+            tex.replace(r"\; ()", "")  # noqa: W605
+            .replace(r"\; {}", "")  # noqa: W605
             .replace("()", "")
             .replace("_{}", "")
             .replace("{{}}", "")
@@ -597,7 +597,7 @@ template   : %s
 
         with_units = r"${tex} {sep} \left[{units}\right]$".format(
             tex=tex,
-            sep="$\n$" if self.new_line_for_units else "\;",  # noqa: W605
+            sep=r"$\n$" if self.new_line_for_units else r"\;",  # noqa: W605
             units=units,
         )
 

--- a/solarwindpy/plotting/labels/composition.py
+++ b/solarwindpy/plotting/labels/composition.py
@@ -29,7 +29,7 @@ class Ion(base.Base):
 
     @property
     def units(self):
-        return "\#"  # noqa: W605
+        return r"\#"  # noqa: W605
 
     @property
     def path(self):
@@ -84,7 +84,7 @@ class ChargeState(base.Base):
         uA = self.ionA.units
         uB = self.ionB.units
 
-        units = "\#"  # noqa: W605
+        units = r"\#"  # noqa: W605
         if uA != uB:
             units = f"{uA}/{uB}"
 

--- a/solarwindpy/plotting/labels/datetime.py
+++ b/solarwindpy/plotting/labels/datetime.py
@@ -26,7 +26,7 @@ class Timedelta(special.ArbitraryLabel):
 
     @property
     def with_units(self):
-        return f"${self.tex} \; [{self.units}]$"  # noqa: W605
+        return f"${self.tex} \\; [{self.units}]$"  # noqa: W605
 
     #     @property
     #     def dt(self):
@@ -50,7 +50,10 @@ class Timedelta(special.ArbitraryLabel):
     @property
     def units(self):
         try:
-            return "%s \; \mathrm{%s}" % (self.offset.n, self.offset.name)  # noqa: W605
+            return "%s \\; \\mathrm{%s}" % (
+                self.offset.n,
+                self.offset.name,
+            )  # noqa: W605
         except AttributeError:
             return base._inU["unknown"]
 
@@ -90,7 +93,7 @@ class DateTime(special.ArbitraryLabel):
 
     @property
     def tex(self):
-        return r"\mathrm{%s}" % self.kind.replace(" ", " \; ")  # noqa: W605
+        return r"\mathrm{%s}" % self.kind.replace(" ", r" \; ")  # noqa: W605
 
     @property
     def path(self):
@@ -103,7 +106,7 @@ class DateTime(special.ArbitraryLabel):
 class Epoch(special.ArbitraryLabel):
     r"""Create epoch analysis labels, e.g. ``Hour of Day``."""
 
-    def __init__(self, kind, of_thing, space="\,"):  # noqa: W605
+    def __init__(self, kind, of_thing, space=r"\,"):  # noqa: W605
         """Instantiate the label.
 
         Parameters
@@ -159,7 +162,7 @@ class Epoch(special.ArbitraryLabel):
         self._smaller = new.title()
 
     def set_space(self, new):
-        if new not in (" ", "\,", "\;", "\:"):  # noqa: W605
+        if new not in (" ", r"\,", r"\;", r"\:"):  # noqa: W605
             raise ValueError(f"Unrecognized Space {new}")
 
         self._space = new
@@ -225,7 +228,7 @@ class January1st(special.ArbitraryLabel):
 
     @property
     def tex(self):
-        return r"\mathrm{January 1^{st} of Year}".replace(" ", " \; ")  # noqa: W605
+        return r"\mathrm{January 1^{st} of Year}".replace(" ", r" \; ")  # noqa: W605
 
     @property
     def path(self):

--- a/solarwindpy/plotting/labels/special.py
+++ b/solarwindpy/plotting/labels/special.py
@@ -41,11 +41,11 @@ class ManualLabel(ArbitraryLabel):
         return (
             r"$\mathrm{%s} \; [%s]$"
             % (  # noqa: W605
-                self.tex.replace(" ", " \; "),  # noqa: W605
+                self.tex.replace(" ", r" \; "),  # noqa: W605
                 self.unit,
             )
         ).replace(
-            "\; []", ""  # noqa: W605
+            r"\; []", ""  # noqa: W605
         )
 
     @property
@@ -188,7 +188,7 @@ class Power(ArbitraryLabel):
         super().__init__()
 
     def __str__(self):
-        return f"${self.tex} \; [{self.units}]$"  # noqa: W605
+        return f"${self.tex} \\; [{self.units}]$"  # noqa: W605
 
     @property
     def tex(self):
@@ -295,7 +295,7 @@ class CountOther(ArbitraryLabel):
     def __str__(self):
         return r"${tex} {sep} [{units}]$".format(
             tex=self.tex,
-            sep="$\n$" if self.new_line_for_units else "\;",  # noqa: W605
+            sep=r"$\n$" if self.new_line_for_units else r"\;",  # noqa: W605
             units=self.units,
         )
 
@@ -382,7 +382,7 @@ class MathFcn(ArbitraryLabel):
         self.build_label()
 
     def __str__(self):
-        sep = "$\n$" if self.new_line_for_units else "\;"  # noqa: W605
+        sep = r"$\n$" if self.new_line_for_units else r"\;"  # noqa: W605
         return rf"""${self.tex} {sep} \left[{self.units}\right]$"""
 
     @property
@@ -529,7 +529,7 @@ class SSN(ArbitraryLabel):
     @property
     def tex(self):
         return (r"\mathrm{%s SSN}" % self.pretty_kind).replace(
-            " ", " \; "  # noqa: W605
+            " ", r" \; "  # noqa: W605
         )  # noqa: W605
 
     @property

--- a/solarwindpy/tests/test_plasma.py
+++ b/solarwindpy/tests/test_plasma.py
@@ -1519,7 +1519,7 @@ class PlasmaTestBase(ABC):
             with self.assertRaisesRegex(
                 ValueError,
                 # Match this sentence at start of string.
-                "^Plasma must contain \(core\) protons to estimate electrons.",  # noqa: W605
+                r"^Plasma must contain \(core\) protons to estimate electrons.",  # noqa: W605
             ):
                 self.object_testing.estimate_electrons()
 


### PR DESCRIPTION
## Summary
- silence invalid escape sequence warnings by using raw strings or escaped backslashes
- keep style with Black and run test suite

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884df160124832c852cb1a5f1303d39