### PR TITLE
Fix specific entropy test

### DIFF
--- a/solarwindpy/core/plasma.py
+++ b/solarwindpy/core/plasma.py
@@ -754,7 +754,10 @@ class Plasma(base.Base):
         pth = pth.reorder_levels(["C", "S"], axis=1).sort_index(axis=1)
 
         if len(species) == 1:
-            pth = pth.T.groupby("S").sum().T
+            if "+" in species[0]:
+                pth = pth.T.groupby(level="C").sum().T
+            else:
+                pth = pth.xs(slist[0], axis=1, level="S")
             # pth["S"] = species[0]
             # pth = pth.set_index("S", append=True).unstack()
             # pth = pth.reorder_levels(["C", "S"], axis=1).sort_index(axis=1)

--- a/solarwindpy/tests/test_plasma.py
+++ b/solarwindpy/tests/test_plasma.py
@@ -2322,7 +2322,6 @@ class PlasmaTestBase(ABC):
             with self.assertRaisesRegex(ValueError, msg0):
                 ot.vdf_ratio(scomma, ssum)
 
-    @pytest.mark.skip(reason="Not implemented")
     def test_specific_entropy(self):
         # print_inline_debug_info = False
         ot = self.object_testing


### PR DESCRIPTION
## Summary
- unskip specific entropy test
- include scalar component when calculating thermal pressure per-species

## Testing
- `flake8 solarwindpy/core/plasma.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e3156f50832c94c011984d3749e5