### PR TITLE
Fix Plasma.pth and enable regression test

### DIFF
--- a/solarwindpy/core/plasma.py
+++ b/solarwindpy/core/plasma.py
@@ -754,7 +754,7 @@ class Plasma(base.Base):
         pth = pth.reorder_levels(["C", "S"], axis=1).sort_index(axis=1)
 
         if len(species) == 1:
-            pth = pth.T.groupby("S").sum().T
+            pth = pth.T.groupby("C").sum().T
             # pth["S"] = species[0]
             # pth = pth.set_index("S", append=True).unstack()
             # pth = pth.reorder_levels(["C", "S"], axis=1).sort_index(axis=1)

--- a/solarwindpy/tests/test_plasma.py
+++ b/solarwindpy/tests/test_plasma.py
@@ -359,7 +359,6 @@ class PlasmaTestBase(ABC):
                 with self.assertRaises(ValueError):
                     ot.thermal_speed(",".join(s))
 
-    @pytest.mark.skip(reason="Not implemented")
     def test_pth(self):
         # print_inline_debug_info = False
         # Test that Plasma returns each Ion plasma independently.


### PR DESCRIPTION
## Summary
- enable `test_pth`
- fix `Plasma.pth` so single-species call returns component pressures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e30ff098832ca1465e8e1794a511