### PR TITLE
Refactor core imports

### DIFF
--- a/solarwindpy/core/__init__.py
+++ b/solarwindpy/core/__init__.py
@@ -1,1 +1,23 @@
-r""":py:mod:`solarwindpy` core classes."""
+"""Core classes and utilities for :mod:`solarwindpy`."""
+
+from .base import Base, Core
+from .vector import Vector
+from .tensor import Tensor
+from .ions import Ion
+from .plasma import Plasma
+from .spacecraft import Spacecraft
+from .units_constants import Units, Constants
+from .alfvenic_turbulence import AlfvenicTurbulence
+
+__all__ = [
+    "Base",
+    "Core",
+    "Vector",
+    "Tensor",
+    "Ion",
+    "Plasma",
+    "Spacecraft",
+    "Units",
+    "Constants",
+    "AlfvenicTurbulence",
+]

--- a/solarwindpy/core/alfvenic_turbulence.py
+++ b/solarwindpy/core/alfvenic_turbulence.py
@@ -25,10 +25,7 @@ from collections import namedtuple
 # `.copy(deep=True)`, so we want to make sure that this doesn't
 # accidentally cause a problem.
 
-try:
-    from . import base
-except ImportError:
-    import base
+from . import base
 
 AlvenicTurbAveraging = namedtuple("AlvenicTurbAveraging", "window,min_periods")
 

--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -14,10 +14,7 @@ import numpy as np
 import pandas as pd
 from pandas import MultiIndex as MI
 
-try:
-    from . import units_constants as uc
-except ImportError:
-    import units_constants as uc
+from . import units_constants as uc
 
 
 class Core(ABC):

--- a/solarwindpy/core/ions.py
+++ b/solarwindpy/core/ions.py
@@ -8,15 +8,9 @@ contains Vector and Tensor objects.
 from __future__ import annotations
 import pandas as pd
 
-
-try:
-    from . import base
-    from . import vector
-    from . import tensor
-except ImportError:
-    import base
-    import vector
-    import tensor
+from . import base
+from . import vector
+from . import tensor
 
 
 class Ion(base.Base):

--- a/solarwindpy/core/plasma.py
+++ b/solarwindpy/core/plasma.py
@@ -36,18 +36,11 @@ import itertools
 # `.copy(deep=True)`, so we want to make sure that this doesn't
 # accidentally cause a problem.
 
-try:
-    from . import base
-    from . import vector
-    from . import ions
-    from . import spacecraft
-    from . import alfvenic_turbulence as alf_turb
-except ImportError:
-    import base
-    import vector
-    import ions
-    import spacecraft
-    import alfvenic_turbulence as alf_turb
+from . import base
+from . import vector
+from . import ions
+from . import spacecraft
+from . import alfvenic_turbulence as alf_turb
 
 
 class Plasma(base.Base):
@@ -917,7 +910,7 @@ class Plasma(base.Base):
 
         if len(species) > 1:
             # if "S" in pth.columns.names:
-#             ani = pth.pow(exp, axis=1, level="C").product(axis=1, level="S")
+            #             ani = pth.pow(exp, axis=1, level="C").product(axis=1, level="S")
             ani = pth.pow(exp, axis=1, level="C").T.groupby(level="S").prod().T
         else:
             ani = pth.pow(exp, axis=1).product(axis=1)
@@ -1233,7 +1226,7 @@ species: {}
         # My guess is that following this line, we'd insert the subtraction
         # of the dynamic pressure with the appropriate alignment of the
         # species as necessary.
-#         dp = dp.sum(axis=1, level="S" if multi_species else None)
+        #         dp = dp.sum(axis=1, level="S" if multi_species else None)
         if multi_species:
             dp = dp.T.groupby(level="S").sum().T
         else:

--- a/solarwindpy/core/spacecraft.py
+++ b/solarwindpy/core/spacecraft.py
@@ -11,12 +11,8 @@ import numpy as np
 # `.copy(deep=True)`, so we want to make sure that this doesn't
 # accidentally cause a problem.
 
-try:
-    from . import base
-    from . import vector
-except ImportError:
-    import base
-    import vector
+from . import base
+from . import vector
 
 
 class Spacecraft(base.Base):

--- a/solarwindpy/core/tensor.py
+++ b/solarwindpy/core/tensor.py
@@ -4,10 +4,7 @@
 import pandas as pd
 from typing import Union
 
-try:
-    from . import base
-except ImportError:
-    import base
+from . import base
 
 
 class Tensor(base.Base):

--- a/solarwindpy/core/vector.py
+++ b/solarwindpy/core/vector.py
@@ -9,10 +9,7 @@ from typing import Union
 import numpy as np
 import pandas as pd
 
-try:
-    from . import base
-except ImportError:
-    import base
+from . import base
 
 
 class Vector(base.Base):


### PR DESCRIPTION
## Summary
- simplify core imports by using explicit relative imports
- reexport core classes in `solarwindpy.core`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897cd92edc832ca3967408361bfd48