### PR TITLE
Update publish workflow trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [master]
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
## Summary
- run PyPI publish workflow only when pushing to the `master` branch

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a812ae214832c8138731a2d68a5d1