### PR TITLE
Add FFPlot unit tests

### DIFF
--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -201,9 +201,9 @@ class Base(Core):
         ), "%s.species can't contain '+'." % (self.__class__.__name__)
         species = tuple(sorted(species))
         return species
-    
+
     def head(self):
         return self.data.head()
-    
+
     def tail(self):
         return self.data.tail()

--- a/solarwindpy/tests/fitfunctions/test_plots.py
+++ b/solarwindpy/tests/fitfunctions/test_plots.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+"""Tests for :mod:`solarwindpy.fitfunctions.plots`."""
+
+import numpy as np
+from types import SimpleNamespace
+from matplotlib import pyplot as plt
+from matplotlib.axes import Axes
+
+from solarwindpy.fitfunctions.core import Observations, UsedRawObs
+from solarwindpy.fitfunctions.plots import FFPlot
+from solarwindpy.fitfunctions.tex_info import TeXinfo
+
+
+def make_plotter():
+    """Return a simple ``FFPlot`` instance for testing."""
+    plt.switch_backend("Agg")
+
+    x_raw = np.arange(5.0)
+    y_fit = 2.0 * x_raw + 1.0
+    y_raw = y_fit.copy()
+    mask = np.array([False, True, True, True, False])
+
+    used = Observations(x_raw[mask], y_raw[mask] + 0.5, np.full(mask.sum(), 0.1))
+    raw = Observations(x_raw, y_raw, np.full_like(x_raw, 0.1))
+    obs = UsedRawObs(used=used, raw=raw, tk_observed=mask)
+
+    tex_info = TeXinfo({"a": 0.0}, {"a": 0.0}, "f(x)", 0.0, 1.0)
+    fit_result = SimpleNamespace(fun=np.zeros(mask.sum()))
+
+    return FFPlot(obs, y_fit, tex_info, fit_result)
+
+
+def test_plot_raw_returns_axes():
+    plotter = make_plotter()
+    ax, *_ = plotter.plot_raw()
+    assert isinstance(ax, Axes)
+
+
+def test_plot_used_returns_axes():
+    plotter = make_plotter()
+    ax, *_ = plotter.plot_used()
+    assert isinstance(ax, Axes)
+
+
+def test_plot_fit_returns_axes():
+    plotter = make_plotter()
+    ax = plotter.plot_fit(annotate=False)
+    assert isinstance(ax, Axes)
+
+
+def test_plot_residuals_returns_axes():
+    plotter = make_plotter()
+    ax = plotter.plot_residuals()
+    assert isinstance(ax, Axes)
+
+
+def test_residuals_computation():
+    plotter = make_plotter()
+    mask = plotter.observations.tk_observed
+    expected_abs = plotter.y_fit[mask] - plotter.observations.used.y
+    np.testing.assert_allclose(plotter.residuals(pct=False), expected_abs)
+
+    expected_pct = 100.0 * expected_abs / plotter.y_fit[mask]
+    np.testing.assert_allclose(plotter.residuals(pct=True), expected_pct)


### PR DESCRIPTION
## Summary
- add FFPlot tests for plotting methods and residual calculations
- fix flake8 whitespace warnings in `Base`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce459f104832cac8c74e0b46f12bf