### PR TITLE
Add tests for exponential fit functions

### DIFF
--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -201,9 +201,9 @@ class Base(Core):
         ), "%s.species can't contain '+'." % (self.__class__.__name__)
         species = tuple(sorted(species))
         return species
-    
+
     def head(self):
         return self.data.head()
-    
+
     def tail(self):
         return self.data.tail()

--- a/solarwindpy/tests/fitfunctions/test_exponentials.py
+++ b/solarwindpy/tests/fitfunctions/test_exponentials.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+"""Tests for exponential fit functions."""
+
+import numpy as np
+import numpy.testing as npt
+
+from solarwindpy.fitfunctions.exponentials import (
+    Exponential,
+    ExponentialPlusC,
+    ExponentialCDF,
+)
+
+
+def test_exponential_p0_and_tex():
+    x = np.arange(4, dtype=float)
+    y = np.array([1.0, 2.0, 3.0, 4.0])
+    ff = Exponential(x, y)
+    assert ff.p0 == [1.0, 4.0]
+    assert ff.TeX_function == r"f(x)=A \cdot e^{-cx}"
+
+
+def test_exponentialplusc_p0_and_tex():
+    x = np.arange(4, dtype=float)
+    y = np.array([1.0, 2.0, 3.0, 4.0])
+    ff = ExponentialPlusC(x, y)
+    assert ff.p0 == [1.0, 4.0, 0.0]
+    assert ff.TeX_function == r"f(x)=A \cdot e^{-cx} + d"
+
+
+def test_exponentialcdf_p0_tex_and_set_y0():
+    x = np.arange(4, dtype=float)
+    y = np.array([1.0, 2.0, 3.0, 4.0])
+    ff = ExponentialCDF(x, y)
+    assert ff.p0 == [2.5]
+    assert ff.TeX_function == r"f(x)=A \left(1 - e^{-cx}\right)"
+
+    ff.set_y0(10.0)
+    func = ff.function
+    result = func(np.array([0.0, 1.0]), 2.0)
+    expected = 10.0 * (1.0 - np.exp(-2.0 * np.array([0.0, 1.0])))
+    npt.assert_allclose(result, expected)


### PR DESCRIPTION
## Summary
- add unit tests for exponential fit functions
- tidy trailing whitespace in `core/base.py`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce45d90c0832c8f6fbd884bf0d1a2