### PR TITLE
Add tests for Line fit function

### DIFF
--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -201,9 +201,9 @@ class Base(Core):
         ), "%s.species can't contain '+'." % (self.__class__.__name__)
         species = tuple(sorted(species))
         return species
-    
+
     def head(self):
         return self.data.head()
-    
+
     def tail(self):
         return self.data.tail()

--- a/solarwindpy/fitfunctions/lines.py
+++ b/solarwindpy/fitfunctions/lines.py
@@ -43,7 +43,7 @@ class Line(FitFunction):
 
         m = dy / dx
         m = np.median(m)
-        b = (m * x) - y
+        b = y - (m * x)
         b = np.median(b)
 
         p0 = [m, b]

--- a/solarwindpy/tests/fitfunctions/test_lines.py
+++ b/solarwindpy/tests/fitfunctions/test_lines.py
@@ -1,0 +1,25 @@
+import numpy as np
+from solarwindpy.fitfunctions.lines import Line
+
+
+def test_line_fit_and_properties():
+    x = np.linspace(0, 10, 20)
+    m_true = 2.5
+    b_true = -1.0
+    y = m_true * x + b_true
+
+    fit = Line(x, y)
+
+    m0, b0 = fit.p0
+    assert np.isclose(m0, m_true)
+    assert np.isclose(b0, b_true)
+
+    fit.make_fit()
+
+    assert np.isclose(fit.popt["m"], m_true)
+    assert np.isclose(fit.popt["b"], b_true)
+    assert np.isclose(fit.x_intercept, -b_true / m_true)
+
+    x_test = np.array([-1.0, 0.0, 4.0, 7.5])
+    expected = m_true * x_test + b_true
+    assert np.allclose(fit(x_test), expected)


### PR DESCRIPTION
## Summary
- fix intercept estimation in `Line` initial guess
- add regression tests for line fitting
- clean trailing whitespace in `core.base`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce45e21d4832ca1b47cab54b72baf