### PR TITLE
Add basic tests for instabilities

### DIFF
--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -201,9 +201,9 @@ class Base(Core):
         ), "%s.species can't contain '+'." % (self.__class__.__name__)
         species = tuple(sorted(species))
         return species
-    
+
     def head(self):
         return self.data.head()
-    
+
     def tail(self):
         return self.data.tail()

--- a/solarwindpy/instabilities/verscharen2016.py
+++ b/solarwindpy/instabilities/verscharen2016.py
@@ -347,7 +347,7 @@ class StabilityCondition(object):
         """
         is_unstable = {
             k: self.instability_tests[k](self.anisotropy, v)
-            for k, v in self.instability_thresholds.iteritems()
+            for k, v in self.instability_thresholds.items()
         }
         is_unstable = pd.concat(is_unstable, axis=1).sort_index(axis=1)
 
@@ -357,7 +357,7 @@ class StabilityCondition(object):
         is_unstable.mask(self.instability_thresholds.isnull(), inplace=True)
 
         # When an instability is NaN, we have to check the other instabilities.
-        for key, column in is_unstable.iteritems():
+        for key, column in is_unstable.items():
 
             # Temporarily replace the NaNs here with False because NaNs don"t
             # qualify as unstable on their own. We make the replacement here
@@ -508,7 +508,7 @@ class StabilityContours(object):
             target_contours = target_contours.loc[:, tk_kind]
         target_contours = target_contours.stack()
 
-        for k, v in target_contours.iteritems():
+        for k, v in target_contours.items():
             gamma, itype = k
 
             if plot_gamma is not None:

--- a/solarwindpy/tests/instabilities/test_beta_ani.py
+++ b/solarwindpy/tests/instabilities/test_beta_ani.py
@@ -1,0 +1,17 @@
+import matplotlib
+import pandas as pd
+from solarwindpy.instabilities.beta_ani import BetaRPlot
+
+matplotlib.use("Agg")
+
+
+def test_beta_r_plot_make_plot():
+    beta = pd.Series([0.1, 1.0, 10.0])
+    ani = pd.Series([1.1, 0.9, 1.3])
+    plot = BetaRPlot(beta, ani, "p")
+    ax, cbar = plot.make_plot()
+    from matplotlib.axes import Axes
+    from matplotlib.colorbar import Colorbar
+
+    assert isinstance(ax, Axes)
+    assert isinstance(cbar, Colorbar)

--- a/solarwindpy/tests/instabilities/test_init.py
+++ b/solarwindpy/tests/instabilities/test_init.py
@@ -1,0 +1,13 @@
+import importlib
+
+from solarwindpy import instabilities
+
+
+def test_instabilities_all():
+    expected = {"verscharen2016", "beta_ani"}
+    assert set(instabilities.__all__) == expected
+    # ensure modules import correctly via __all__
+    for name in expected:
+        assert isinstance(
+            importlib.import_module(f"solarwindpy.instabilities.{name}"), object
+        )

--- a/solarwindpy/tests/instabilities/test_verscharen2016.py
+++ b/solarwindpy/tests/instabilities/test_verscharen2016.py
@@ -1,0 +1,29 @@
+import matplotlib
+import numpy as np
+import pandas as pd
+from solarwindpy.instabilities import verscharen2016 as v
+
+matplotlib.use("Agg")
+
+
+def test_beta_ani_inst_basic():
+    beta = np.array([1.0, 2.0])
+    result = v.beta_ani_inst(beta, a=0.367, b=-0.408, c=0.011)
+    expected = 1 + (0.367 / ((beta - 0.011) ** -0.408))
+    assert np.allclose(result, expected)
+
+
+def test_stability_condition_shapes():
+    beta = pd.Series([1.0, 2.0, 3.0])
+    ani = pd.Series([1.1, 0.9, 1.3])
+    cond = v.StabilityCondition(-2, beta, ani)
+    assert cond.instability_thresholds.shape == (3, 4)
+    assert cond.is_unstable.shape == (3, 4)
+    assert cond.stability_bin.shape[0] == 3
+
+
+def test_stability_contours_lengths():
+    beta = np.logspace(-2, 1, 5)
+    sc = v.StabilityContours(beta)
+    for values in sc.contours.to_numpy().ravel():
+        assert len(values) == len(beta)


### PR DESCRIPTION
## Summary
- add tests for instabilities modules
- fix use of deprecated `iteritems`
- clean up whitespace in `core.base`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce3ceb8ec832c9e07657548625fa4