### PR TITLE
Add mi_tuples index name test

### DIFF
--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -201,9 +201,9 @@ class Base(Core):
         ), "%s.species can't contain '+'." % (self.__class__.__name__)
         species = tuple(sorted(species))
         return species
-    
+
     def head(self):
         return self.data.head()
-    
+
     def tail(self):
         return self.data.tail()

--- a/solarwindpy/tests/test_base_mi_tuples.py
+++ b/solarwindpy/tests/test_base_mi_tuples.py
@@ -1,0 +1,11 @@
+import pandas as pd
+import pandas.testing as pdt
+
+from solarwindpy.core.base import Base
+
+
+def test_mi_tuples_returns_index_with_names():
+    tuples = (("v", "x", "p"), ("b", "y", ""))
+    result = Base.mi_tuples(tuples)
+    expected = pd.MultiIndex.from_tuples(tuples, names=["M", "C", "S"])
+    pdt.assert_index_equal(result, expected)


### PR DESCRIPTION
## Summary
- test that `Base.mi_tuples` returns a `MultiIndex` with names `['M', 'C', 'S']`
- clean trailing whitespace in `core/base.py` to satisfy flake8

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cee69b420832c816dbed7b4afec6f