### PR TITLE
Add tests for datetime index checks

### DIFF
--- a/solarwindpy/tests/test_core_verify_datetimeindex.py
+++ b/solarwindpy/tests/test_core_verify_datetimeindex.py
@@ -1,0 +1,32 @@
+import logging
+
+import pandas as pd
+
+from solarwindpy.core.base import Core
+
+
+class DummyCore(Core):
+    """Simple Core subclass exposing :meth:`_verify_datetimeindex`."""
+
+    def _clean_species_for_setting(self, *species: str):
+        return species
+
+    def verify(self, data: pd.DataFrame) -> None:
+        self._verify_datetimeindex(data)
+
+
+def test_non_datetime_index_warning(caplog):
+    core = DummyCore()
+    df = pd.DataFrame({"a": [1, 2]})
+    with caplog.at_level(logging.WARNING):
+        core.verify(df)
+    assert "non-DatetimeIndex" in caplog.text
+
+
+def test_non_monotonic_datetime_index_warning(caplog):
+    core = DummyCore()
+    idx = pd.to_datetime(["2020-01-02", "2020-01-01"])
+    df = pd.DataFrame({"a": [1, 2]}, index=idx)
+    with caplog.at_level(logging.WARNING):
+        core.verify(df)
+    assert "not monotonically increasing" in caplog.text


### PR DESCRIPTION
## Summary
- create a `DummyCore` subclass to expose `_verify_datetimeindex`
- verify warnings for non-DatetimeIndex and non-monotonic DatetimeIndex using `caplog`

## Testing
- `flake8 solarwindpy/tests/test_core_verify_datetimeindex.py`
- `black solarwindpy/tests/test_core_verify_datetimeindex.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cee6eb0bc832c90d10af36cd95a87