### PR TITLE
Fix Ion sound speed calculation

### DIFF
--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -201,9 +201,9 @@ class Base(Core):
         ), "%s.species can't contain '+'." % (self.__class__.__name__)
         species = tuple(sorted(species))
         return species
-    
+
     def head(self):
         return self.data.head()
-    
+
     def tail(self):
         return self.data.tail()

--- a/solarwindpy/core/ions.py
+++ b/solarwindpy/core/ions.py
@@ -190,19 +190,19 @@ class Ion(base.Base):
         return pth
 
     @property
-    def cs(self) -> pd.Series:
+    def cs(self) -> pd.DataFrame:
         """
         Calculate the species' sound speed.
 
         Returns
         -------
-        pd.Series
+        pd.DataFrame
             Sound speed of the ion species.
         """
         pth = self.pth * self.units.pth
         rho = self.rho * self.units.rho
         gamma = self.constants.polytropic_index["scalar"]
-        cs = pth.divide(rho).multiply(gamma).pow(0.5) / self.units.cs
+        cs = pth.divide(rho, axis=0).multiply(gamma).pow(0.5) / self.units.cs
         cs.name = "cs"
         return cs
 

--- a/solarwindpy/tests/test_ions.py
+++ b/solarwindpy/tests/test_ions.py
@@ -182,6 +182,17 @@ class IonTestBase(ABC):
         pdt.assert_series_equal(S, ot.S)
         pdt.assert_series_equal(ot.S, ot.specific_entropy)
 
+    def test_cs(self):
+        m = self.mass
+        n = self.data.n * 1e6
+        w = self.data.w * 1e3
+        rho = n * m
+        pth = w.pow(2).multiply(0.5 * rho, axis=0)
+        gamma = 5.0 / 3.0
+        cs = (pth.divide(rho, axis=0) * gamma).pow(0.5) / 1e3
+        cs.name = "cs"
+        pdt.assert_frame_equal(cs, self.object_testing.cs)
+
 
 class TestIonA(base.AlphaTest, IonTestBase, base.SWEData):
     pass


### PR DESCRIPTION
## Summary
- correct axis alignment in `Ion.cs`
- add regression test for sound speed
- clean whitespace in `core.base`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cee78d194832c889d2e03f91bae3d