### PR TITLE
Add tests for Spacecraft error handling

### DIFF
--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -201,9 +201,9 @@ class Base(Core):
         ), "%s.species can't contain '+'." % (self.__class__.__name__)
         species = tuple(sorted(species))
         return species
-    
+
     def head(self):
         return self.data.head()
-    
+
     def tail(self):
         return self.data.tail()

--- a/solarwindpy/tests/test_spacecraft.py
+++ b/solarwindpy/tests/test_spacecraft.py
@@ -210,3 +210,21 @@ class TestPSP(TestBase, TestCase):
         self.assertIsInstance(ot.carrington, pd.DataFrame)
         pdt.assert_index_equal(cols, ot.carrington.columns)
         pdt.assert_frame_equal(carr, ot.carrington)
+
+
+class TestSpacecraftErrors(TestCase):
+    def setUp(self):
+        data = base.TestData().spacecraft_data
+        p = data.xs("pos_HCI", axis=1, level="M")
+        df = pd.concat({"pos": p}, axis=1, names=["M"], sort=True).sort_index(axis=1)
+        self.sc = spacecraft.Spacecraft(df, "psp", "hci")
+
+    def test_invalid_frame_raises(self):
+        msg = "Unrecognized frame"
+        with self.assertRaisesRegex(NotImplementedError, msg):
+            self.sc.set_frame_name("bad", "psp")
+
+    def test_invalid_name_raises(self):
+        msg = "Unrecognized name"
+        with self.assertRaisesRegex(NotImplementedError, msg):
+            self.sc.set_frame_name("hci", "unknown")


### PR DESCRIPTION
## Summary
- trim whitespace in `Base` to satisfy flake8
- test invalid frame and name handling in `Spacecraft.set_frame_name`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cee836244832c8ea4bbbe2986f28d