### PR TITLE
Add averaging_info test for AlfvenicTurbulence

### DIFF
--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -201,9 +201,9 @@ class Base(Core):
         ), "%s.species can't contain '+'." % (self.__class__.__name__)
         species = tuple(sorted(species))
         return species
-    
+
     def head(self):
         return self.data.head()
-    
+
     def tail(self):
         return self.data.tail()

--- a/solarwindpy/tests/test_alfvenic_turbulence.py
+++ b/solarwindpy/tests/test_alfvenic_turbulence.py
@@ -188,6 +188,12 @@ class AlfvenicTrubulenceTestBase(ABC):
         ot = self.object_testing
         pdt.assert_frame_equal(measurements, ot.measurements)
 
+    def test_averaging_info(self):
+        ot = self.object_testing
+        avg = ot.averaging_info
+        expected = turb.AlvenicTurbAveraging(self.test_window, self.test_periods)
+        self.assertEqual(expected, avg)
+
     #    def test_auto_reindex(self):
     #
     #        v = self.unrolled_data.loc[:, "v"].drop(1, axis=0)


### PR DESCRIPTION
## Summary
- fix trailing whitespace in `core/base.py`
- assert that `AlfvenicTurbulence.averaging_info` stores input window and periods

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cee8ae034832cb73a985143a7ebeb