### PR TITLE
Add tests for Units and Constants constructors

### DIFF
--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -201,9 +201,9 @@ class Base(Core):
         ), "%s.species can't contain '+'." % (self.__class__.__name__)
         species = tuple(sorted(species))
         return species
-    
+
     def head(self):
         return self.data.head()
-    
+
     def tail(self):
         return self.data.tail()

--- a/solarwindpy/tests/test_units_constants.py
+++ b/solarwindpy/tests/test_units_constants.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Tests for units and constants containers."""
+
+import pandas as pd
+
+from solarwindpy.core import units_constants as uc
+
+
+def test_units_attributes():
+    u = uc.Units()
+    assert hasattr(u, "b")
+    assert isinstance(u.b, float)
+    assert hasattr(u, "v")
+    assert isinstance(u.v, float)
+
+
+def test_constants_attributes():
+    c = uc.Constants()
+    assert hasattr(c, "kb")
+    assert isinstance(c.kb, pd.Series)
+    assert hasattr(c, "misc")
+    assert isinstance(c.misc, pd.Series)


### PR DESCRIPTION
## Summary
- add a minimal test to instantiate `Units` and `Constants`
- trim trailing whitespace in `core/base.py` so flake8 passes

## Testing
- `black solarwindpy/tests/test_units_constants.py solarwindpy/core/base.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cee90d078832c9856f0f285f82f1e