### PR TITLE
Add tests for Units and Constants constructors

### DIFF
--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -201,9 +201,9 @@ class Base(Core):
         ), "%s.species can't contain '+'." % (self.__class__.__name__)
         species = tuple(sorted(species))
         return species
-    
+
     def head(self):
         return self.data.head()
-    
+
     def tail(self):
         return self.data.tail()

--- a/solarwindpy/tests/test_units_constants.py
+++ b/solarwindpy/tests/test_units_constants.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Tests for units and constants containers."""
+
+import pandas as pd
+
+from solarwindpy.core import units_constants as uc
+
+
+def test_units_attributes():
+    u = uc.Units()
+    attrs = [
+        "bfield",
+        "b",
+        "v",
+        "w",
+        "dv",
+        "ca",
+        "cs",
+        "cfms",
+        "pth",
+        "temperature",
+        "n",
+        "rho",
+        "beta",
+        "lnlambda",
+        "nuc",
+        "nc",
+        "qpar",
+        "distance2sun",
+        "specific_entropy",
+    ]
+    for attr in attrs:
+        assert hasattr(u, attr)
+        assert isinstance(getattr(u, attr), float)
+
+
+def test_constants_attributes():
+    c = uc.Constants()
+    attrs = [
+        "misc",
+        "kb",
+        "m_in_mp",
+        "m",
+        "m_amu",
+        "charges",
+        "charge_states",
+        "polytropic_index",
+    ]
+    for attr in attrs:
+        assert hasattr(c, attr)
+        assert isinstance(getattr(c, attr), pd.Series)


### PR DESCRIPTION
## Summary
- add a minimal test to instantiate `Units` and `Constants`
- trim trailing whitespace in `core/base.py` so flake8 passes
- test that `Units` exposes all conversion-factor attributes
- test that `Constants` provides series for masses, charges, and polytropic indices

## Testing
- `black solarwindpy/tests/test_units_constants.py`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cee90d078832c9856f0f285f82f1e