### PR TITLE
docs: expand documentation checklist

### DIFF
--- a/solarwindpy/plans/checklist_documentation.md
+++ b/solarwindpy/plans/checklist_documentation.md
@@ -2,10 +2,15 @@
 
 ## 1. Evaluate the current state
 
+- [ ] Clarify documentation goals: clear, searchable, versioned API docs and tutorials (#PR_NUMBER)
 - [ ] Evaluate existing docs infrastructure under `docs/` (e.g., Sphinx config, extensions) (#PR_NUMBER)
 - [ ] Verify that the config (`docs/source/conf.py`) loads the correct extensions: `autodoc`, `todo`, `mathjax`, `viewcode`, `githubpages` (#PR_NUMBER)
+- [ ] Ensure `autosummary_generate = True` and enable `sphinx.ext.autosummary` in `docs/source/conf.py` (#PR_NUMBER)
 - [ ] Confirm that the theme (`sphinx_rtd_theme`) is set appropriately (#PR_NUMBER)
 - [ ] Check that source file suffix is `.rst` and master doc is `index.rst` (#PR_NUMBER)
+- [ ] Ensure `version` in `docs/source/conf.py` is dynamically loaded from package metadata (#PR_NUMBER)
+- [ ] Commit `DOCUMENTATION_PLAN.md` to the repository root (#PR_NUMBER)
+- [ ] Apply updates to `docs/source/conf.py` and `setup.cfg` as outlined in the documentation plan (#PR_NUMBER)
 
 ## 2. Choose a documentation generator
 
@@ -17,10 +22,11 @@
 
 - [ ] Create `docs/requirements.txt` listing `sphinx`, `sphinx_rtd_theme`, `sphinx.ext.napoleon`, etc. (#PR_NUMBER)
 - [ ] Update `docs/Makefile` and `docs/make.bat` to include targets for `html`, `clean`, `spellcheck` (#PR_NUMBER)
-- [ ] Add CI workflow in `.github/workflows/doc-build.yml` to install docs requirements and run `make html`, failing on warnings (#PR_NUMBER)
+- [ ] Add CI workflow in `.github/workflows/doc-build.yml` to install docs requirements and run `sphinx-build` via `actions/setup-python`, failing on warnings (#PR_NUMBER)
 
 ## 4. Improve docstrings
 
+- [ ] Update `setup.cfg` to include docstring checks `D205` and `D406` (#PR_NUMBER)
 - [ ] Audit all public modules and classes for missing docstrings (#PR_NUMBER)
 - [ ] Standardize all existing docstrings to NumPy style (`Parameters`, `Returns`, `Raises` sections) (#PR_NUMBER)
 - [ ] Add missing sections (`Examples`, `Notes`, `Attributes`) where relevant (#PR_NUMBER)
@@ -36,23 +42,31 @@
 - [ ] Create `installation.rst` with installation instructions (pip, conda) (#PR_NUMBER)
 - [ ] Create `usage.rst` with basic usage examples (#PR_NUMBER)
 - [ ] Create `tutorial.rst` with a step-by-step tutorial (#PR_NUMBER)
+- [ ] Create `docs/source/modules.rst` with a toctree of modules (#PR_NUMBER)
+- [ ] Add `docs/source/tutorial/quickstart.rst` with installation steps and basic workflow (#PR_NUMBER)
 - [ ] Generate API reference via `sphinx-apidoc` and include in `api_reference.rst` (#PR_NUMBER)
 
 ## 6. Build and validate documentation locally
 
 - [ ] Run `sphinx-apidoc` to regenerate module stub files (#PR_NUMBER)
 - [ ] Execute `make html` in `docs/` and confirm no errors or warnings (#PR_NUMBER)
+- [ ] Enable `autosummary` to pre-generate summary pages for modules (#PR_NUMBER)
 - [ ] Test links, code snippets, and formatting in the generated site (#PR_NUMBER)
 
 ## 7. Host documentation
 
 - [ ] Configure Read the Docs by adding a `.readthedocs.yaml` with Python version and build commands (#PR_NUMBER)
+- [ ] Enable builds for each branch, including `update-2025`, on Read the Docs (#PR_NUMBER)
 - [ ] Or set up GitHub Pages deployment:
-  - [ ] Create `.github/workflows/deploy-docs.yml` to build and push to `gh-pages` branch (#PR_NUMBER)
+  - [ ] Create `.github/workflows/deploy-docs.yml` to build and push to `gh-pages` branch using `actions/setup-python` and `sphinx-build` (#PR_NUMBER)
 - [ ] Add a documentation badge to `README.rst` (#PR_NUMBER)
 
 ## 8. Documentation maintenance
 
 - [ ] Document docstring conventions and update workflow in `CONTRIBUTING.md` (#PR_NUMBER)
-- [ ] Set up linting for documentation (e.g., `flake8-docstrings`, `rst-lint`) in CI (#PR_NUMBER)
+- [ ] Set up linting for documentation (e.g., `flake8-docstrings`, `rst-lint`, `doc8`) in CI (#PR_NUMBER)
+- [ ] Run `make doc8` in CI to enforce reStructuredText style (#PR_NUMBER)
+- [ ] Regularly update tutorial pages with new use cases (#PR_NUMBER)
+- [ ] Add a pull request template reminding contributors to update docstrings (#PR_NUMBER)
 - [ ] Schedule periodic review of documentation coverage (#PR_NUMBER)
+- [ ] Review documentation updates and merge via pull request (#PR_NUMBER)


### PR DESCRIPTION
## Summary
- expand documentation checklist with missing plan items like autosummary, modules.rst, quickstart, doc8 linting, and branch-specific hosting tasks

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f8aaced9c832ca7b2c064bb916b95