### PR TITLE
docs(plans): remove redundant AGENTS note

### DIFF
--- a/solarwindpy/plans/checklist_test_plan_fit_functions.md
+++ b/solarwindpy/plans/checklist_test_plan_fit_functions.md
@@ -228,8 +228,3 @@ _For each class:_
 - [ ] API contracts: string formats (`TeX`), plotting behaviors, and property outputs must be stable (#PR)
 - [ ] Edge cases: zero-size data, insufficient observations, bad weights, solver failures—ensures graceful degradation (#PR)
 
----
-
-_Aligns with AGENTS.md: run with `pytest -q`, enforce no skipped tests, maintain code style with `flake8` & `black`._
-
----


### PR DESCRIPTION
## Summary
- remove closing AGENTS reminder so fitfunctions checklist references guidelines only in intro

## Testing
- `npx --yes markdownlint-cli solarwindpy/plans/checklist_test_plan_fit_functions.md` (fails: MD013/line-length, MD007/ul-indent, ...) 
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f96719730832caba05804074e59f5