### PR TITLE
Add Vector.set_data column validation test

### DIFF
--- a/solarwindpy/tests/test_vector_errors.py
+++ b/solarwindpy/tests/test_vector_errors.py
@@ -1,0 +1,14 @@
+import pandas as pd
+import pytest
+
+from solarwindpy import vector
+
+
+def test_set_data_missing_column_raises():
+    index = pd.date_range("2020-01-01", periods=1)
+    valid = pd.DataFrame({"x": [0.0], "y": [1.0], "z": [2.0]}, index=index)
+    vec = vector.Vector(valid)
+
+    missing = pd.DataFrame({"x": [0.0], "y": [1.0]}, index=index)
+    with pytest.raises(ValueError, match=r"Required columns: .*\nProvided: .*"):
+        vec.set_data(missing)


### PR DESCRIPTION
## Summary
- test that Vector.set_data complains when columns are missing

## Testing
- `flake8 solarwindpy/tests/test_vector_errors.py`
- `black solarwindpy/tests/test_vector_errors.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cee734914832cb6f52f847c56b9a0