### PR TITLE
Add error tests for spacecraft set_data

### DIFF
--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -201,9 +201,9 @@ class Base(Core):
         ), "%s.species can't contain '+'." % (self.__class__.__name__)
         species = tuple(sorted(species))
         return species
-    
+
     def head(self):
         return self.data.head()
-    
+
     def tail(self):
         return self.data.tail()


### PR DESCRIPTION
## Summary
- test spacecraft.set_data fails when `pos` columns are missing
- check non-datetime index raises assertion
- clean trailing whitespace in `Base`

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cee868554832c994512c947a92f73