### PR TITLE
Add sound speed NotImplemented tests

### DIFF
--- a/solarwindpy/core/base.py
+++ b/solarwindpy/core/base.py
@@ -201,9 +201,9 @@ class Base(Core):
         ), "%s.species can't contain '+'." % (self.__class__.__name__)
         species = tuple(sorted(species))
         return species
-    
+
     def head(self):
         return self.data.head()
-    
+
     def tail(self):
         return self.data.tail()

--- a/solarwindpy/tests/test_plasma.py
+++ b/solarwindpy/tests/test_plasma.py
@@ -1053,6 +1053,17 @@ class PlasmaTestBase(ABC):
             with self.assertRaisesRegex(NotImplementedError, regex_msg):
                 self.object_testing.caani("+".join(combo), pdynamic=True)
 
+    def test_sound_speed_not_implemented(self):
+        class DummyUC:
+            polytropic_index = {"scalar": 5 / 3}
+
+        sp = self.stuple[0]
+        self.object_testing.units_constants = DummyUC()
+        with self.assertRaises(NotImplementedError):
+            self.object_testing.sound_speed(sp)
+        with self.assertRaises(NotImplementedError):
+            self.object_testing.cs(sp)
+
     def test_lnlambda(self):
         #        print_inline_debug_info = True
 


### PR DESCRIPTION
## Summary
- ensure sound speed methods raise `NotImplementedError`
- clean whitespace in `core/base.py`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cee8f91cc832c96ea1d09b07a10ad