### PR TITLE
docs: expand SpiralMesh checklist items

### DIFF
--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
@@ -242,8 +242,11 @@ ______________________________________________________________________
   (#PR_NUMBER)
 - [ ] Verify `.bin_id` property returns bin IDs (#PR_NUMBER)
 - [ ] Verify `.cat` property returns category labels (#PR_NUMBER)
-- [ ] Verify `.data`, `.initial_edges`, `.mesh`, `.min_per_bin`,
-  `.cell_filter_thresholds` props (#PR_NUMBER)
+- [ ] Verify `.data` property returns stored input data (#PR_NUMBER)
+- [ ] Verify `.initial_edges` property returns initial bin edges (#PR_NUMBER)
+- [ ] Verify `.mesh` property returns computed mesh (#PR_NUMBER)
+- [ ] Verify `.min_per_bin` property returns minimum per bin (#PR_NUMBER)
+- [ ] Verify `.cell_filter_thresholds` property returns filter thresholds (#PR_NUMBER)
 - [ ] Test `set_cell_filter_thresholds(density=0.1,size=0.9)` updates thresholds
   (#PR_NUMBER)
 - [ ] Verify `set_cell_filter_thresholds(bad=…)` raises `KeyError`


### PR DESCRIPTION
## Summary
- split combined SpiralMesh property verification into separate checklist tasks

## Testing
- `markdownlint solarwindpy/plans/combined_test_plan_with_checklist_plotting.md` (issues: MD013, MD024)
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fa87b1964832c9b366657d9c798d5