### PR TITLE
docs: clarify tmp_path dependency for combined_test_plan_with_checklist_solar_activity.md

### DIFF
--- a/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity.md
@@ -19,14 +19,14 @@ ______________________________________________________________________
 - `pytest`
 - `unittest.mock` (for HTTP and filesystem mocking)
 - `pytest-monkeypatch` (monkeypatch fixture)
-- `pytest-tmp_path` (temporary directories for caching)
+- `tmp_path` fixture (built into `pytest` for temporary directories)
 
 ### Checklist
 
 - [ ] Ensure `pytest` is available (#PR_NUMBER)
 - [ ] Ensure `unittest.mock` is available for HTTP and filesystem mocking (#PR_NUMBER)
 - [ ] Ensure `pytest-monkeypatch` plugin is available (#PR_NUMBER)
-- [ ] Ensure `pytest-tmp_path` plugin is available (#PR_NUMBER)
+- [ ] Ensure `tmp_path` fixture from core `pytest` is available (#PR_NUMBER)
 
 ______________________________________________________________________
 


### PR DESCRIPTION
## Summary
- fix test plan to state `tmp_path` fixture comes from core pytest
- update related checklist item for clarity

## Testing
- `markdownlint solarwindpy/plans/combined_test_plan_with_checklist_solar_activity.md | head -n 20`
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_688fa7f77d5c832c9645a2bab852d8f2