### PR TITLE
docs: track doc8 linting and flake8 D205/D406 rules for combined_plan_with_checklist_documentation.md

### DIFF
--- a/solarwindpy/plans/checklist_documentation.md
+++ b/solarwindpy/plans/checklist_documentation.md
@@ -54,5 +54,6 @@
 ## 8. Documentation maintenance
 
 - [ ] Document docstring conventions and update workflow in `CONTRIBUTING.md` (#PR_NUMBER)
-- [ ] Set up linting for documentation (e.g., `flake8-docstrings`, `rst-lint`) in CI (#PR_NUMBER)
+- [ ] Set up linting for documentation (e.g., `flake8-docstrings`, `rst-lint`, `doc8`) in CI (#PR_NUMBER)
+- [ ] Ensure `flake8-docstrings` rules D205/D406 are enabled in `setup.cfg` (#PR_NUMBER)
 - [ ] Schedule periodic review of documentation coverage (#PR_NUMBER)

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation.md
@@ -102,5 +102,6 @@ SolarWindPy/
 | Create `.github/workflows/deploy-docs.yml` to build and push to `gh-pages` | not started | | |
 | Add a documentation badge to `README.rst` | not started | | |
 | Document docstring conventions and update workflow in `CONTRIBUTING.md` | not started | | |
-| Set up linting for documentation (e.g., `flake8-docstrings`, `rst-lint`) in CI | not started | | |
+| Set up linting for documentation (e.g., `flake8-docstrings`, `rst-lint`, `doc8`) in CI | not started | | |
+| Ensure `flake8-docstrings` rules D205/D406 are enabled in `setup.cfg` | not started | | |
 | Schedule periodic review of documentation coverage | not started | | |


### PR DESCRIPTION
## Summary
- note doc8 alongside flake8-docstrings and rst-lint in docs linting task
- add checklist item to ensure flake8-docstrings rules D205/D406 are enabled

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fa81d7f30832cb20e2bdb4ef67680