### PR TITLE
docs: add PR template reminder for docstrings in combined_plan_with_checklist_documentation.md

### DIFF
--- a/solarwindpy/plans/combined_plan_with_checklist_documentation.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation.md
@@ -69,6 +69,7 @@ SolarWindPy/
 
 - Integrate `doc8` or similar tools for RST linting.
 - Add docstring conventions and workflow guidelines to `CONTRIBUTING.md`.
+- Create a pull request template that reminds contributors to update docstrings.
 - Include a documentation badge in `README.rst`.
 - Schedule periodic reviews of documentation coverage.
 
@@ -104,3 +105,4 @@ SolarWindPy/
 | Document docstring conventions and update workflow in `CONTRIBUTING.md` | not started | | |
 | Set up linting for documentation (e.g., `flake8-docstrings`, `rst-lint`) in CI | not started | | |
 | Schedule periodic review of documentation coverage | not started | | |
+| Create `.github/PULL_REQUEST_TEMPLATE.md` to prompt docstring updates | not started | | |


### PR DESCRIPTION
## Summary
- note need for PR template guiding docstring updates in maintenance plan
- track creation of `.github/PULL_REQUEST_TEMPLATE.md` in documentation checklist

## Testing
- `pymarkdown scan solarwindpy/plans/combined_plan_with_checklist_documentation.md` *(fails: line length)*
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fa81a4798832cbb061d83cc5f65f4