### PR TITLE
docs(plans): split combined plans into task templates

### DIFF
--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/1-Overview-and-Goals.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/1-Overview-and-Goals.md
@@ -1,0 +1,46 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+Combined Documentation Plan and Task List for SolarWindPy (update-2025 branch)
+
+## 🎯 Overview of the Task
+
+- **Aim**: Provide clear, searchable, and versioned API documentation and tutorials.
+- **Scope**:
+  - Auto-generated API reference for all modules and subpackages.
+  - User guide with installation, basic usage, and advanced examples.
+  - Hosted primarily on Read the Docs and mirrored on GitHub Pages.
+
+## 🔧 Framework & Dependencies
+
+- Read the Docs
+- GitHub Pages
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/2-Toolchain-and-Hosting.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/2-Toolchain-and-Hosting.md
@@ -1,0 +1,58 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+Combined Documentation Plan and Task List for SolarWindPy (update-2025 branch)
+
+## 🎯 Overview of the Task
+
+- **Documentation generator**: Sphinx
+  - Extensions: `sphinx.ext.autodoc`, `sphinx.ext.napoleon`, `sphinx.ext.mathjax`, `sphinx.ext.viewcode`, `sphinx.ext.githubpages`.
+  - Theme: `sphinx_rtd_theme`.
+- **Environment**:
+  - `docs/requirements.txt` lists Sphinx and related extensions.
+  - `docs/Makefile` and `docs/make.bat` provide `html`, `clean`, and `spellcheck` targets.
+- **Hosting**:
+  - Read the Docs for versioned builds.
+  - GitHub Pages via a `gh-pages` branch.
+
+## 🔧 Framework & Dependencies
+
+- Sphinx
+- Read the Docs
+- GitHub Pages
+
+## 📂 Affected Files and Paths
+
+- docs/make.bat
+- docs/requirements.txt
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Evaluate existing docs infrastructure under `docs/` (e.g., Sphinx config, extensions)
+- [ ] Decide to continue with Sphinx versus evaluate alternatives
+- [ ] Review benefits of plugins such as `sphinx.ext.viewcode` and `sphinx.ext.githubpages`
+- [ ] Create `docs/requirements.txt` listing Sphinx and related extensions
+- [ ] Update `docs/Makefile` and `docs/make.bat` to include `html`, `clean`, and `spellcheck` targets
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/3-Repository-Structure.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/3-Repository-Structure.md
@@ -1,0 +1,54 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+Combined Documentation Plan and Task List for SolarWindPy (update-2025 branch)
+
+## 🎯 Overview of the Task
+
+```
+SolarWindPy/
+├── docs/
+│   ├── source/
+│   │   ├── conf.py
+│   │   ├── index.rst
+│   │   ├── modules.rst
+│   │   └── tutorial/
+│   │       └── quickstart.rst
+│   └── Makefile
+├── solarwindpy/
+│   └── ... (code packages)
+└── plans/combined_plan_with_checklist_documentation.md
+```
+
+## 🔧 Framework & Dependencies
+
+None
+
+## 📂 Affected Files and Paths
+
+- plans/combined_plan_with_checklist_documentation.md
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/4-Configuration-and-Standards.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/4-Configuration-and-Standards.md
@@ -1,0 +1,60 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+Combined Documentation Plan and Task List for SolarWindPy (update-2025 branch)
+
+## 🎯 Overview of the Task
+
+- Update `docs/source/conf.py`:
+  - Add Napoleon extension and enable `autosummary_generate = True`.
+  - Confirm `html_theme = "sphinx_rtd_theme"`.
+  - Ensure `flake8-docstrings` rules D205/D406 are enabled.
+  - Retrieve `version` from package metadata instead of hardcoding it.
+- Standardize docstrings to NumPy style across the codebase.
+  - Include `Parameters`, `Returns`, `Raises`, and `Examples` sections.
+  - Audit modules (`core/`, `fitfunctions/`, `instabilities/`, `plotting/`, etc.) for missing or incomplete docstrings.
+
+## 🔧 Framework & Dependencies
+
+- Sphinx
+- flake8
+
+## 📂 Affected Files and Paths
+
+- docs/source/conf.py
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Verify that `docs/source/conf.py` loads `autodoc`, `todo`, `mathjax`, `viewcode`, and `githubpages`
+- [ ] Retrieve package `version` dynamically in `docs/source/conf.py`
+- [ ] Confirm that the theme `sphinx_rtd_theme` is set appropriately
+- [ ] Check that the source file suffix is `.rst` and master doc is `index.rst`
+- [ ] Add `sphinx.ext.napoleon` extension to parse NumPy/Google-style docstrings
+- [ ] Audit all public modules and classes for missing docstrings
+- [ ] Standardize all existing docstrings to NumPy style
+- [ ] Add missing sections such as `Examples`, `Notes`, and `Attributes` where relevant
+- [ ] Remove or address any `TODO` placeholders related to documentation
+- [ ] Ensure `flake8-docstrings` rules D205/D406 are enabled in `setup.cfg`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/5-Documentation-Content.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/5-Documentation-Content.md
@@ -1,0 +1,57 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+Combined Documentation Plan and Task List for SolarWindPy (update-2025 branch)
+
+## 🎯 Overview of the Task
+
+- Create `docs/source/modules.rst` with a toctree covering core modules.
+- Update `docs/source/index.rst` to reference:
+  - `installation.rst`
+  - `usage.rst`
+  - `tutorial.rst`
+  - `api_reference.rst`
+- Add tutorial pages such as `docs/source/tutorial/quickstart.rst` for installation and basic workflow.
+- Generate API reference pages with `sphinx-apidoc` and `autosummary`.
+
+## 🔧 Framework & Dependencies
+
+- Sphinx
+
+## 📂 Affected Files and Paths
+
+- docs/source/index.rst
+- docs/source/modules.rst
+- docs/source/tutorial/quickstart.rst
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Update `docs/source/index.rst` to include `installation.rst`, `usage.rst`, `tutorial.rst`, and `api_reference.rst`
+- [ ] Create `installation.rst` with installation instructions (pip, conda)
+- [ ] Create `usage.rst` with basic usage examples
+- [ ] Create `tutorial.rst` with a step-by-step tutorial
+- [ ] Generate API reference via `sphinx-apidoc` and include in `api_reference.rst`
+- [ ] Run `sphinx-apidoc` to regenerate module stub files
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/6-CI-CD-and-Validation.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/6-CI-CD-and-Validation.md
@@ -1,0 +1,51 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+Combined Documentation Plan and Task List for SolarWindPy (update-2025 branch)
+
+## 🎯 Overview of the Task
+
+- Add CI workflow `.github/workflows/doc-build.yml` to build documentation and fail on warnings.
+- Use GitHub Actions to deploy to `gh-pages`.
+- Configure Read the Docs with `.readthedocs.yaml`.
+- Validate locally by running `sphinx-apidoc` and `make html` without errors or warnings and testing links and snippets.
+
+## 🔧 Framework & Dependencies
+
+- Sphinx
+- Read the Docs
+
+## 📂 Affected Files and Paths
+
+- .github/workflows/doc-build.yml
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Add CI workflow `.github/workflows/doc-build.yml` to install docs requirements and run `make html`
+- [ ] Execute `make html` in `docs/` and confirm no errors or warnings
+- [ ] Test links, code snippets, and formatting in the generated site
+- [ ] Configure Read the Docs with `.readthedocs.yaml`
+- [ ] Create `.github/workflows/deploy-docs.yml` to build and push to `gh-pages`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/7-Maintenance.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/7-Maintenance.md
@@ -1,0 +1,51 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+Combined Documentation Plan and Task List for SolarWindPy (update-2025 branch)
+
+## 🎯 Overview of the Task
+
+- Integrate `doc8` or similar tools for RST linting.
+- Add docstring conventions and workflow guidelines to `CONTRIBUTING.md`.
+- Create a pull request template that reminds contributors to update docstrings.
+- Include a documentation badge in `README.rst`.
+- Schedule periodic reviews of documentation coverage.
+
+## 🔧 Framework & Dependencies
+
+None
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Add a documentation badge to `README.rst`
+- [ ] Document docstring conventions and update workflow in `CONTRIBUTING.md`
+- [ ] Set up linting for documentation (e.g., `flake8-docstrings`, `rst-lint`, `doc8`) in CI
+- [ ] Schedule periodic review of documentation coverage
+- [ ] Create `.github/PULL_REQUEST_TEMPLATE.md` to prompt docstring updates
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/1-Common-fixtures.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/1-Common-fixtures.md
@@ -1,0 +1,61 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Combined Test Plan and Checklist for `solarwindpy.fitfunctions` (update-2025 branch)
+
+> **Goal:** Verify correctness, robustness, and full coverage (public and non‑public APIs) of the `fitfunctions` submodule.
+> **Framework:** `pytest` with fixtures; follow `AGENTS.md` guidelines (`pytest -q`, no skipping, style with `flake8` and `black`).
+
+## 🎯 Overview of the Task
+
+```python
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.optimize import OptimizeResult
+
+from solarwindpy.fitfunctions import core, gaussians, trend_fits, plots, tex_info
+```
+
+- `simple_linear_data`: 1D arrays `x = np.linspace(0, 1, 20)`, `y = 2 * x + 1 + noise`, `w = np.ones_like(x)`.
+- `gauss_data`: sample `x`, generate `y = A · exp(-0.5((x - μ)/σ)²) + noise`.
+- `small_n`: too few points to trigger `sufficient_data -> ValueError`.
+
+## 🔧 Framework & Dependencies
+
+- pytest
+- flake8
+- black
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Implement `simple_linear_data` fixture
+- [ ] Implement `gauss_data` fixture
+- [ ] Implement `small_n` fixture
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/2-corepy--FitFunction.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/2-corepy--FitFunction.md
@@ -1,0 +1,128 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Combined Test Plan and Checklist for `solarwindpy.fitfunctions` (update-2025 branch)
+
+> **Goal:** Verify correctness, robustness, and full coverage (public and non‑public APIs) of the `fitfunctions` submodule.
+> **Framework:** `pytest` with fixtures; follow `AGENTS.md` guidelines (`pytest -q`, no skipping, style with `flake8` and `black`).
+
+## 🎯 Overview of the Task
+
+#### 2.1 Initialization & observation filtering
+
+- `_clean_raw_obs`
+  - Mismatched shapes → `ValueError`.
+  - Valid inputs → arrays returned.
+- `_build_one_obs_mask`
+  - Test with `xmin`, `xmax`, `None` → masks correct.
+- `_build_outside_mask`
+  - `outside=None` → all `True`.
+  - Valid tuple → only outside points `True`.
+- `set_fit_obs`
+  - Combined masks apply correctly for `x`, `y`, `wmin`, `wmax`, and `logy`.
+
+##### Checklist
+
+#### 2.2 Argument introspection
+
+- `_set_argnames`
+  - On subclass with known signature → `argnames` matches function arguments.
+
+##### Checklist
+
+#### 2.3 Fitting workflow
+
+- `_run_least_squares`
+  - Monkey-patch `scipy.optimize.least_squares` to return dummy `OptimizeResult`.
+  - Test default kwargs (`loss`, `method`, etc.).
+  - Passing invalid `args` kwarg → `ValueError`.
+- `_calc_popt_pcov_psigma_chisq`
+  - Feed dummy `res` with known `fun`, `jac`, produce known `popt`, `pcov`, `psigma`, `chisq`.
+- `make_fit`
+  - **Success:** returns `None`, sets `_popt`, `_psigma`, `_pcov`, `_chisq_dof`, `_fit_result`, builds `TeX_info` and `plotter`.
+  - **Insufficient data:** returns `ValueError` if `return_exception=True`.
+  - **Optimization failure:** raises `RuntimeError` or returns exception.
+
+##### Checklist
+
+#### 2.4 Public properties
+
+- `__str__` → `"<ClassName> (<TeX_function>)"`.
+- `__call__` → returns `function(x, *popt)` array.
+- **Properties:**
+  - `argnames`, `fit_bounds`, `chisq_dof`, `dof`, `fit_result`,
+  - `initial_guess_info`, `nobs`, `observations`, `plotter`,
+  - `popt`, `psigma`, `psigma_relative`, `combined_popt_psigma`, `pcov`, `rsq`,
+  - `sufficient_data`, `TeX_info`.
+- **Test:** after a dummy fit, each property yields expected dtype, shape, or value.
+
+##### Checklist
+
+## 🔧 Framework & Dependencies
+
+- pytest
+- flake8
+- black
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Test `_clean_raw_obs` for mismatched shapes (`ValueError`)
+- [ ] Test `_clean_raw_obs` for valid inputs (arrays returned)
+- [ ] Test `_build_one_obs_mask` with `xmin`, `xmax`, `None` (masks correct)
+- [ ] Test `_build_outside_mask` with `outside=None` (all `True`)
+- [ ] Test `_build_outside_mask` with valid tuple (only outside points `True`)
+- [ ] Test `set_fit_obs` for combined masks (`x`, `y`, `wmin`, `wmax`, `logy`)
+- [ ] Test `_set_argnames` on subclass with known signature (`argnames` matches function arguments)
+- [ ] Test `_run_least_squares` with monkey-patched optimizer (dummy `OptimizeResult`)
+- [ ] Test `_run_least_squares` for default kwargs (`loss`, `method`, etc.)
+- [ ] Test `_run_least_squares` for invalid `args` kwarg (`ValueError`)
+- [ ] Test `_calc_popt_pcov_psigma_chisq` with dummy `res`, known `fun`, `jac` (check outputs)
+- [ ] Test `make_fit` success path (sets internals and helpers)
+- [ ] Test `make_fit` with insufficient data (`ValueError` if `return_exception=True`)
+- [ ] Test `make_fit` on optimization failure (`RuntimeError` or exception)
+- [ ] Test `__str__` returns `"<ClassName> (<TeX_function>)"`
+- [ ] Test `__call__` returns `function(x, *popt)` array
+- [ ] Test `argnames` property after dummy fit
+- [ ] Test `fit_bounds` property after dummy fit
+- [ ] Test `chisq_dof` property after dummy fit
+- [ ] Test `dof` property after dummy fit
+- [ ] Test `fit_result` property after dummy fit
+- [ ] Test `initial_guess_info` property after dummy fit
+- [ ] Test `nobs` property after dummy fit
+- [ ] Test `observations` property after dummy fit
+- [ ] Test `plotter` property after dummy fit
+- [ ] Test `popt` property after dummy fit
+- [ ] Test `psigma` property after dummy fit
+- [ ] Test `psigma_relative` property after dummy fit
+- [ ] Test `combined_popt_psigma` property after dummy fit
+- [ ] Test `pcov` property after dummy fit
+- [ ] Test `rsq` property after dummy fit
+- [ ] Test `sufficient_data` property after dummy fit
+- [ ] Test `TeX_info` property after dummy fit
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/3-gaussianspy--Gaussian-GaussianNormalized-GaussianLn.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/3-gaussianspy--Gaussian-GaussianNormalized-GaussianLn.md
@@ -1,0 +1,79 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Combined Test Plan and Checklist for `solarwindpy.fitfunctions` (update-2025 branch)
+
+> **Goal:** Verify correctness, robustness, and full coverage (public and non‑public APIs) of the `fitfunctions` submodule.
+> **Framework:** `pytest` with fixtures; follow `AGENTS.md` guidelines (`pytest -q`, no skipping, style with `flake8` and `black`).
+
+## 🎯 Overview of the Task
+
+For each class:
+
+#### 3.1 Signature & `function` property
+
+- Call `.function`, inspect returned callable’s signature and behavior on sample `x`.
+
+##### Checklist
+
+#### 3.2 `p0` initial guesses
+
+- With synthetic Gaussian data → `p0` ≈ true `[μ, σ, A]` (tolerance).
+- Empty data → triggers the zero-size-array `ValueError`.
+
+##### Checklist
+
+#### 3.3 `TeX_function`
+
+- Matches expected LaTeX string literal.
+
+##### Checklist
+
+#### 3.4 `make_fit` override
+
+- On success → calls base `make_fit`, sets `TeX_argnames` in `TeX_info`.
+- On forced failure (monkey-patched optimizer) → no exception in `make_fit`, leaves `TeX_argnames` unset.
+
+##### Checklist
+
+## 🔧 Framework & Dependencies
+
+- pytest
+- flake8
+- black
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Test `.function` signature and behavior on sample `x`
+- [ ] Test `p0` with synthetic Gaussian data (matches true `[μ, σ, A]` within tolerance)
+- [ ] Test `p0` with empty data (triggers zero-size-array `ValueError`)
+- [ ] Test `.TeX_function` matches expected LaTeX string literal
+- [ ] Test success path: calls base `make_fit`, sets `TeX_argnames` in `TeX_info`
+- [ ] Test forced failure: no exception in `make_fit`, leaves `TeX_argnames` unset
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/4-trend_fitspy--TrendFit.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/4-trend_fitspy--TrendFit.md
@@ -1,0 +1,113 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Combined Test Plan and Checklist for `solarwindpy.fitfunctions` (update-2025 branch)
+
+> **Goal:** Verify correctness, robustness, and full coverage (public and non‑public APIs) of the `fitfunctions` submodule.
+> **Framework:** `pytest` with fixtures; follow `AGENTS.md` guidelines (`pytest -q`, no skipping, style with `flake8` and `black`).
+
+## 🎯 Overview of the Task
+
+#### 4.1 Initialization & type enforcement
+
+- Valid `agged: pd.DataFrame`, `trendfunc: FitFunction` subclass → no error.
+- Invalid `ffunc1d` or `trendfunc` → raises `TypeError`.
+
+##### Checklist
+
+#### 4.2 Properties
+
+- `__str__`, `agged`, `ffunc1d_class`, `trendfunc_class`, `ffuncs` (after `make_ffunc1ds`),
+  `popt_1d`, `psigma_1d`, `trend_func`, `bad_fits`, `popt1d_keys`, `trend_logx`, `labels`.
+
+##### Checklist
+
+#### 4.3 1D-fit pipeline
+
+- `make_ffunc1ds`: builds `Series` of `FitFunction` instances.
+- `make_1dfits`: mark bad fits (return value ≠ `None`), remove them from `ffuncs` → `bad_fits` populated.
+
+##### Checklist
+
+#### 4.4 Trend fitting
+
+- `make_trend_func`: with valid `popt_1d`, builds `trend_func`; insufficient fits → `ValueError`.
+
+##### Checklist
+
+#### 4.5 Plot helpers
+
+- `plot_all_ffuncs`, `plot_all_popt_1d`, `plot_trend_fit_resid`,
+  `plot_trend_and_resid_on_ffuncs`, `plot_1d_popt_and_trend`
+  - Stub out plotting (monkey-patch `.plotter` methods to record calls), ensure axes returned.
+
+##### Checklist
+
+#### 4.6 Label sharing
+
+- `set_agged` type check; `set_fitfunctions` logic; `set_shared_labels` updates label objects.
+
+##### Checklist
+
+## 🔧 Framework & Dependencies
+
+- pytest
+- flake8
+- black
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Test valid `agged: pd.DataFrame` and `trendfunc: FitFunction` subclass (no error)
+- [ ] Test invalid `ffunc1d` or `trendfunc` (raises `TypeError`)
+- [ ] Test `__str__` property
+- [ ] Test `agged` property
+- [ ] Test `ffunc1d_class` property
+- [ ] Test `trendfunc_class` property
+- [ ] Test `ffuncs` after `make_ffunc1ds`
+- [ ] Test `popt_1d` property
+- [ ] Test `psigma_1d` property
+- [ ] Test `trend_func` property
+- [ ] Test `bad_fits` property
+- [ ] Test `popt1d_keys` property
+- [ ] Test `trend_logx` property
+- [ ] Test `labels` property
+- [ ] Test `make_ffunc1ds` builds `Series` of `FitFunction` instances
+- [ ] Test `make_1dfits` marks bad fits and populates `bad_fits`
+- [ ] Test `make_trend_func` with valid `popt_1d` (builds `trend_func`)
+- [ ] Test `make_trend_func` with insufficient fits (`ValueError`)
+- [ ] Test `plot_all_ffuncs` helper
+- [ ] Test `plot_all_popt_1d` helper
+- [ ] Test `plot_trend_fit_resid` helper
+- [ ] Test `plot_trend_and_resid_on_ffuncs` helper
+- [ ] Test `plot_1d_popt_and_trend` helper
+- [ ] Stub out plotting to record calls and verify axes returned
+- [ ] Test `set_agged` type check
+- [ ] Test `set_fitfunctions` logic
+- [ ] Test `set_shared_labels` updates label objects
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/5-plotspy--FFPlot.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/5-plotspy--FFPlot.md
@@ -1,0 +1,113 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Combined Test Plan and Checklist for `solarwindpy.fitfunctions` (update-2025 branch)
+
+> **Goal:** Verify correctness, robustness, and full coverage (public and non‑public APIs) of the `fitfunctions` submodule.
+> **Framework:** `pytest` with fixtures; follow `AGENTS.md` guidelines (`pytest -q`, no skipping, style with `flake8` and `black`).
+
+## 🎯 Overview of the Task
+
+#### 5.1 Initialization & basic attributes
+
+- `__init__` with dummy `Observations`, `y_fit`, `TeXinfo`, dummy `OptimizeResult`, `fitfunction_name` → no errors.
+- `__str__`, `labels`, `log` default `(False, False)`, `observations`, `fitfunction_name`, `fit_result`, `y_fit`.
+
+##### Checklist
+
+#### 5.2 Path generation
+
+- Vary `labels.x`, `labels.y`, optional `labels.z` → `path` property concatenates correctly.
+
+##### Checklist
+
+#### 5.3 State mutators
+
+- `set_fitfunction_name`, `set_fit_result`, `set_observations` (shape assertions).
+
+##### Checklist
+
+#### 5.4 Internal helpers
+
+- `_estimate_markevery` with small and huge `observations.used.x.size`.
+- `_format_hax`, `_format_rax`: stub axes → grid/scale calls, ensure correct axes methods invoked.
+
+##### Checklist
+
+#### 5.5 Plot methods
+
+- `plot_raw`, `plot_used`, `plot_fit`, `plot_raw_used_fit`, `plot_residuals`, `plot_raw_used_fit_resid`
+  - Provide dummy axes (monkey-patch `plt.subplots`) and assert returned axes and legend/text behavior.
+  - For `pct=True/False`, robust branch, missing `fit_result.fun` → skip second curve.
+
+##### Checklist
+
+#### 5.6 Label & style setters
+
+- `set_labels` updates `labels` namedtuple, unexpected key → `KeyError`.
+- `set_log` toggles `log` flags.
+- `set_TeX_info` stores `TeXinfo`.
+
+##### Checklist
+
+## 🔧 Framework & Dependencies
+
+- pytest
+- flake8
+- black
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Test `__init__` with dummy inputs (no errors)
+- [ ] Test `__str__` method
+- [ ] Test `labels` property
+- [ ] Test default `log` equals `(False, False)`
+- [ ] Test `observations` property
+- [ ] Test `fitfunction_name` property
+- [ ] Test `fit_result` property
+- [ ] Test `y_fit` property
+- [ ] Test `path` concatenation for different label combinations
+- [ ] Test `set_fitfunction_name`
+- [ ] Test `set_fit_result`
+- [ ] Test `set_observations` with shape assertions
+- [ ] Test `_estimate_markevery` for small and large datasets
+- [ ] Test `_format_hax` with stub axes
+- [ ] Test `_format_rax` with stub axes
+- [ ] Test `plot_raw` method
+- [ ] Test `plot_used` method
+- [ ] Test `plot_fit` method
+- [ ] Test `plot_raw_used_fit` method
+- [ ] Test `plot_residuals` for kinds `'simple'`, `'robust'`, `'both'`
+- [ ] Test `plot_raw_used_fit_resid` method
+- [ ] Provide dummy axes and monkey-patch `plt.subplots`, verify axes and legend/text behavior
+- [ ] Test `pct=True/False`, robust branch, missing `fit_result.fun` (skip second curve)
+- [ ] Test `set_labels` updates `labels` and raises `KeyError` on unknown key
+- [ ] Test `set_log` toggles `log` flags
+- [ ] Test `set_TeX_info` stores `TeXinfo`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/6-tex_infopy--TeXinfo.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/6-tex_infopy--TeXinfo.md
@@ -1,0 +1,88 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Combined Test Plan and Checklist for `solarwindpy.fitfunctions` (update-2025 branch)
+
+> **Goal:** Verify correctness, robustness, and full coverage (public and non‑public APIs) of the `fitfunctions` submodule.
+> **Framework:** `pytest` with fixtures; follow `AGENTS.md` guidelines (`pytest -q`, no skipping, style with `flake8` and `black`).
+
+## 🎯 Overview of the Task
+
+#### 6.1 Construction & storage
+
+- Valid inputs; invalid types → `TypeError` or `ValueError` in setters.
+
+##### Checklist
+
+#### 6.2 Properties & formatting
+
+- `info` / `__str__` with various flag combinations.
+- Properties: `initial_guess_info`, `chisq_dof`, `npts`, `popt`, `psigma`, `rsq`,
+  `TeX_argnames`, `TeX_function`, `TeX_popt`, `TeX_relative_error`.
+
+##### Checklist
+
+#### 6.3 Static/private helpers
+
+- `_check_and_add_math_escapes`: odd `$` → `ValueError`.
+- `_calc_precision`, `_simplify_for_paper`, `_add_additional_info`, `_build_fit_parameter_info`,
+  `annotate_info`, `build_info`, setters, `val_uncert_2_string`.
+
+##### Checklist
+
+## 🔧 Framework & Dependencies
+
+- pytest
+- flake8
+- black
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Test valid construction and invalid types in setters (`TypeError`/`ValueError`)
+- [ ] Test `info` / `__str__` with flag combinations
+- [ ] Test `initial_guess_info` property
+- [ ] Test `chisq_dof` property
+- [ ] Test `npts` property
+- [ ] Test `popt` property
+- [ ] Test `psigma` property
+- [ ] Test `rsq` property
+- [ ] Test `TeX_argnames` property
+- [ ] Test `TeX_function` property
+- [ ] Test `TeX_popt` property
+- [ ] Test `TeX_relative_error` property
+- [ ] Test `_check_and_add_math_escapes` with odd `$` (`ValueError`)
+- [ ] Test `_calc_precision` (exponent from scientific notation)
+- [ ] Test `_simplify_for_paper` (strips zeros/decimals)
+- [ ] Test `_add_additional_info` with `str`, iterable, invalid type
+- [ ] Test `_build_fit_parameter_info` (flag combos, unused kwargs `ValueError`)
+- [ ] Test `annotate_info` with stub axis (`ax.text` calls)
+- [ ] Test `build_info` (same as `info` with explicit kwargs)
+- [ ] Test all setters for type/key-consistency errors
+- [ ] Test `val_uncert_2_string` with value/uncertainty pairs (e.g., `3.1415± 0.01`)
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/7-Justification.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/7-Justification.md
@@ -1,0 +1,51 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Combined Test Plan and Checklist for `solarwindpy.fitfunctions` (update-2025 branch)
+
+> **Goal:** Verify correctness, robustness, and full coverage (public and non‑public APIs) of the `fitfunctions` submodule.
+> **Framework:** `pytest` with fixtures; follow `AGENTS.md` guidelines (`pytest -q`, no skipping, style with `flake8` and `black`).
+
+## 🎯 Overview of the Task
+
+1. **Safety and regression**: non‑public helpers guard data integrity.
+1. **Numerical correctness**: fitting and parameter extraction must remain accurate.
+1. **API contracts**: string formats (`TeX`), plotting behaviors, and property outputs must be stable.
+1. **Edge cases**: zero‑size data, insufficient observations, bad weights, solver failures—ensures graceful degradation.
+
+*Aligns with `AGENTS.md`: run with `pytest -q`, enforce no skipped tests, maintain code style with `flake8` and `black`.*
+
+## 🔧 Framework & Dependencies
+
+- pytest
+- flake8
+- black
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/1-basepy.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/1-basepy.md
@@ -1,0 +1,93 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+Combined Test Plan for `solarwindpy.plotting` (branch `update-2025`)
+
+Overview
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+#### 1.1 Class `Base` (abstract)
+
+- Instantiation via subclass to ensure `_init_logger`, `_labels`, `_log`, and `path`
+  setup.
+
+- `__str__` returns the class name.
+
+- Properties `data`, `clip`, `log`, `labels`, `path` reflect internal state.
+
+- `set_log(x, y)` toggles `log.x` and `log.y`; cover defaults and explicit
+  values.
+
+- `set_labels(auto_update_path=True)` updates `labels` and regenerates `path`.
+  Passing an unexpected kwarg raises `KeyError`.
+
+  `_labels`, `_log` and `path` are initialized
+
+______________________________________________________________________
+
+## 🔧 Framework & Dependencies
+
+None
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Instantiate a minimal subclass of `Base` to verify `_init_logger`,
+- [ ] Verify that `__str__` returns the class name
+- [ ] Verify that `.data` property returns the internal `_data`
+- [ ] Verify that `.clip` property returns the internal `_clip`
+- [ ] Verify that `.log` property returns the internal `_log`
+- [ ] Verify that `.labels` property returns the internal `_labels`
+- [ ] Verify that `.path` property returns the internal `_path`
+- [ ] Test `set_log()` with defaults toggles `log.x` and `log.y` appropriately
+- [ ] Test `set_log(x=True, y=False)` correctly updates `log` axes
+- [ ] Test `set_labels()` updates labels and regenerates `path`
+- [ ] Verify that `set_labels(unexpected=…)` raises `KeyError`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/2-agg_plotpy.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/2-agg_plotpy.md
@@ -1,0 +1,87 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+Combined Test Plan for `solarwindpy.plotting` (branch `update-2025`)
+
+Overview
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+#### 2.1 Class `AggPlot(Base)`
+
+- Properties `edges`, `categoricals`, `intervals`, `cut`, `clim`,
+  `agg_axes`, `joint`, `grouped`, `axnorm`.
+- Static method `clip_data(data, clip)` handles series vs. DataFrame, `'l'`, `'u'`,
+  and numeric clipping. Invalid types raise `TypeError`.
+- `set_clim(lower, upper)` sets `_clim`.
+- *Justification*: foundation for all histogram and heatmap classes.
+
+______________________________________________________________________
+
+## 🔧 Framework & Dependencies
+
+None
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Verify `.edges` property constructs correct bin-edge arrays
+- [ ] Verify `.categoricals` property returns categorical bins mapping
+- [ ] Verify `.intervals` property returns correct `IntervalIndex` objects
+- [ ] Verify `.cut` property returns the internal `_cut` DataFrame
+- [ ] Verify `.clim` property returns the internal `_clim` tuple
+- [ ] Verify `.agg_axes` returns the correct aggregation column
+- [ ] Verify `.joint` returns a `Series` with a `MultiIndex`
+- [ ] Verify `.grouped` returns a `GroupBy` on the correct axes
+- [ ] Verify `.axnorm` returns the internal `_axnorm` value
+- [ ] Test `clip_data(pd.Series, 'l')`, `'u'`, numeric → correct clipping
+- [ ] Test `clip_data(pd.DataFrame, …)` with lower/upper modes
+- [ ] Verify `clip_data()` raises `TypeError` on unsupported input
+- [ ] Test `set_clim(2, 10)` sets `_clim` to `(2, 10)`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/3-histogramspy.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/3-histogramspy.md
@@ -1,0 +1,222 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+Combined Test Plan for `solarwindpy.plotting` (branch `update-2025`)
+
+Overview
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+#### 3.1 Module exports
+
+- Test that `AggPlot`, `Hist1D`, and `Hist2D` are re-exported correctly.
+
+#### 3.2 `hist1d.py` → Class `Hist1D(AggPlot)`
+
+- `__init__(x, y=None, logx, axnorm, clip_data, nbins, bin_precision)`
+  handles default count vs. y-aggregation and `logx=True` transforms data.
+
+- `_gb_axes` returns `('x',)`.
+
+- `set_path(new, add_scale)` accepts `"auto"` vs. custom paths.
+
+- `set_data(x, y, clip)` ensures correct DataFrame shape and stores clip flag.
+
+- `set_axnorm(new)` validates keys (`d`, `t`); invalid keys raise
+  `AssertionError`.
+
+- `construct_cdf(only_plotted)` produces a CDF or raises `ValueError` for
+  invalid data.
+
+- `_axis_normalizer(agg)` supports None, density, total; invalid values raise
+  `ValueError`.
+
+- `agg(**kwargs)` requires `fcn='count'` with density normalization; otherwise
+  raises `ValueError`.
+
+- `set_labels(y=…)` updates labels; providing `z` raises `ValueError`.
+
+- `make_plot(ax, fcn, transpose_axes, **kwargs)` returns `(ax, (pl, cl, bl))`.
+  Test error bar parameters, transpose axes, and invalid `fcn`.
+
+  & `clip`
+
+  `drawstyle='steps-mid'`
+
+#### 3.3 `hist2d.py` → Class `Hist2D(AggPlot, PlotWithZdata, CbarMaker)`
+
+- `__init__(x, y, z=None, logx, logy, clip_data, nbins, bin_precision)`.
+
+- `_gb_axes` and `_maybe_convert_to_log_scale(x, y)`.
+
+- `set_labels(z=…)` and `set_data(x, y, z, clip)` including log transforms.
+
+- `set_axnorm(new)` accepts `c`, `r`, `t`, `d`; invalid keys raise
+  `AssertionError`.
+
+- `_axis_normalizer(agg)` handles each normalization branch and iter-norm;
+  invalid values raise `ValueError`.
+
+- `agg(**kwargs)` wraps `super().agg`, applies normalizer, and reindexes.
+
+- `_make_cbar(mappable, **kwargs)` provides default ticks for `c`/`r` norms.
+
+- `_limit_color_norm(norm)` applies percentile clipping.
+
+- `make_plot(ax, cbar, limit_color_norm, cbar_kwargs, fcn, alpha_fcn, **kwargs)`
+  returns `(ax, Colorbar|QuadMesh)` and masks invalid data.
+
+  `AssertionError`
+
+______________________________________________________________________
+
+### 3.4 `scatter.py`
+
+#### Class `Scatter(PlotWithZdata, CbarMaker)`
+
+- `__init__(x, y, z=None, clip_data)`.
+- `_format_axis(ax, collection)` updates `sticky_edges` and data limits.
+- `make_plot(ax, cbar, cbar_kwargs, **kwargs)` handles single vs. multiple
+  `z`, colorbar creation, and `clip_data` path.
+
+______________________________________________________________________
+
+### 3.5 `spiral.py`
+
+#### Numba helpers
+
+- `get_counts_per_bin(bins, x, y)` and `calculate_bin_number_with_numba(mesh, x, y)`
+  operate on small synthetic bins/data to produce correct counts and bin
+  assignments.
+
+#### Class `SpiralMesh`
+
+- Properties: `bin_id`, `cat`, `data`, `initial_edges`, `mesh`, `min_per_bin`,
+  `cell_filter_thresholds`.
+- `cell_filter` combines `density` and `size` thresholds.
+- `set_cell_filter_thresholds(density, size)` validates kwargs; invalid keys
+  raise `KeyError`.
+- `set_initial_edges`, `set_min_per_bin`, and `set_data` update internal state.
+- `initialize_bins()` builds mesh of expected shape.
+
+______________________________________________________________________
+
+## 🔧 Framework & Dependencies
+
+None
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Verify `__all__` includes `AggPlot`, `Hist1D`, `Hist2D`
+- [ ] Test `__init__(x_series)` produces a count histogram
+- [ ] Test `__init__(x, y_series)` aggregates `y` values
+- [ ] Test `__init__(…, logx=True)` applies log₁₀ transform to `x`
+- [ ] Verify `_gb_axes` property returns `('x',)`
+- [ ] Test `set_path('auto')` builds path from labels
+- [ ] Test `set_path('custom', add_scale=False)` sets `_path` to `Path('custom')`
+- [ ] Test `set_data(x, y, clip=True)` stores DataFrame with columns `x`,`y`
+- [ ] Verify `.clip` attribute equals `clip` flag
+- [ ] Test `set_axnorm('d')` sets density normalization and updates label
+- [ ] Test `set_axnorm('t')` sets total normalization
+- [ ] Verify `set_axnorm('x')` raises `AssertionError`
+- [ ] Test `construct_cdf(only_plotted=True)` yields correct CDF DataFrame
+- [ ] Verify `construct_cdf()` on non-histogram data raises `ValueError`
+- [ ] Test `_axis_normalizer(None)` returns input unchanged
+- [ ] Test `_axis_normalizer('d')` computes PDF correctly
+- [ ] Test `_axis_normalizer('t')` normalizes by max
+- [ ] Verify `_axis_normalizer('bad')` raises `ValueError`
+- [ ] Test `agg(fcn='count')` with `axnorm='d'` works
+- [ ] Verify `agg(fcn='sum', axnorm='d')` raises `ValueError`
+- [ ] Verify `agg()` output reindexed correctly
+- [ ] Test `set_labels(y='new')` updates y-label
+- [ ] Verify `set_labels(z='z')` raises `ValueError`
+- [ ] Test `make_plot(ax)` returns `(ax,(pl,cl,bl))` with
+- [ ] Test `make_plot(ax, transpose_axes=True)` swaps axes
+- [ ] Verify `make_plot(fcn='bad')` raises `ValueError`
+- [ ] Test `make_plot(ax, errorbar=True)` renders error bars correctly
+- [ ] Test `__init__(x, y)` produces 2D count heatmap
+- [ ] Test `__init__(x, y, z)` aggregates mean of `z`
+- [ ] Verify `_gb_axes` returns `('x','y')`
+- [ ] Test `_maybe_convert_to_log_scale` with `logx/logy=True`
+- [ ] Test `set_data(x, y, z, clip)` applies log transform
+- [ ] Test `set_labels(z='z')` updates z-label
+- [ ] Verify `set_axnorm('c')`, `'r'`, `'t'`, `'d'` work; invalid →
+- [ ] Test `_axis_normalizer()` for each norm branch
+- [ ] Verify `_axis_normalizer(('c','sum'))` applies custom function
+- [ ] Verify `_axis_normalizer('bad')` raises `ValueError`
+- [ ] Test `_make_cbar()` yields correct `ticks` for `c`/`r`
+- [ ] Test `_limit_color_norm()` sets `vmin`,`vmax`,`clip` properly
+- [ ] Test `make_plot(ax, cbar=False)` returns `QuadMesh`
+- [ ] Test `make_plot(limit_color_norm=True, cbar=True)` applies limits
+- [ ] Test `make_plot` masks invalid data via `alpha_fcn`
+- [ ] Test `make_plot` forwards `cbar_kwargs` to colorbar
+- [ ] Test `__init__(x,y)` draws scatter without colorbar
+- [ ] Test `__init__(x,y,z)` draws scatter with colorbar
+- [ ] Verify `_format_axis()` updates `sticky_edges` & data limits
+- [ ] Test `make_plot(ax, cbar=False)` returns `(ax,None)`
+- [ ] Test `make_plot(ax, cbar=True)` returns `(ax,Colorbar)`
+- [ ] Test `clip_data` path invoked when `clip=True`
+- [ ] Test `get_counts_per_bin()` on synthetic bins → correct counts
+- [ ] Test `calculate_bin_number_with_numba()` assigns correct bin IDs
+- [ ] Verify `.bin_id` property returns bin IDs
+- [ ] Verify `.cat` property returns category labels
+- [ ] Verify `.data` property returns stored input data
+- [ ] Verify `.initial_edges` property returns initial bin edges
+- [ ] Verify `.mesh` property returns computed mesh
+- [ ] Verify `.min_per_bin` property returns minimum per bin
+- [ ] Verify `.cell_filter_thresholds` property returns filter thresholds
+- [ ] Test `set_cell_filter_thresholds(density=0.1,size=0.9)` updates thresholds
+- [ ] Verify `set_cell_filter_thresholds(bad=…)` raises `KeyError`
+- [ ] Test `.cell_filter` logic for density & size filters
+- [ ] Test `set_initial_edges()` updates initial bin edges
+- [ ] Test `set_min_per_bin()` updates minimum per bin
+- [ ] Test `set_data()` stores input data
+- [ ] Test `initialize_bins()` constructs mesh of expected shape
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/4-orbitspy.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/4-orbitspy.md
@@ -1,0 +1,108 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+Combined Test Plan for `solarwindpy.plotting` (branch `update-2025`)
+
+Overview
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+#### Class `OrbitPlot(ABC)`
+
+- `__init__(orbit, *args)` validates `orbit` type; invalid types raise
+  `TypeError`.
+- Properties: `_disable_both`, `orbit`, `_orbit_key`, `grouped`.
+- `set_path(*args, orbit=…)` appends orbit path.
+- `set_orbit(new)` sorts orbits and validates type.
+- `make_cut()` adds “Inbound”/“Outbound” (and “Both”) categories.
+
+#### Class `OrbitHist1D(OrbitPlot, Hist1D)`
+
+- `_format_axis(ax)` adds legend.
+- `agg(**kwargs)` merges “Both” leg; disabled via `_disable_both`.
+- `make_plot(ax, fcn, **kwargs)` calls `tools.subplots` and plots each leg.
+
+#### Class `OrbitHist2D(OrbitPlot, Hist2D)`
+
+- `_format_in_out_axes(inbound, outbound)`, `_prune_lower_yaxis_ticks`, and
+  `_format_in_out_both_axes` manage axis formatting.
+
+- `agg(**kwargs)` wraps and normalizes per-orbit.
+
+- `project_1d(axis, project_counts, **kwargs)` returns an `OrbitHist1D`
+  instance.
+
+  inbound/outbound/both
+
+______________________________________________________________________
+
+## 🔧 Framework & Dependencies
+
+None
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Verify invalid `orbit` type in `__init__` raises `TypeError`
+- [ ] Verify `_disable_both` property is `True` by default
+- [ ] Verify `.orbit` property returns the `IntervalIndex`
+- [ ] Verify `_orbit_key` returns `"Orbit"`
+- [ ] Verify `.grouped` groups by `_gb_axes` + `_orbit_key`
+- [ ] Test `set_path(…, orbit=idx)` appends `orbit.path`
+- [ ] Test `set_orbit(idx)` sorts and validates type
+- [ ] Test `make_cut()` adds “Inbound”/“Outbound” (and “Both”) categories
+- [ ] Verify `_format_axis(ax)` adds a legend
+- [ ] Test `agg()` merges “Both” leg when `_disable_both=False`
+- [ ] Test `make_plot(ax)` plots each orbit leg via `tools.subplots()`
+- [ ] Test `_format_in_out_axes()` swaps x-limits and colors spines
+- [ ] Test `_prune_lower_yaxis_ticks()` prunes ticks correctly
+- [ ] Test `_format_in_out_both_axes()` aligns y-limits across
+- [ ] Test `agg()` normalizes per-orbit legs
+- [ ] Test `project_1d('x')` returns a valid `OrbitHist1D`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/5-toolspy.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/5-toolspy.md
@@ -1,0 +1,88 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+Combined Test Plan for `solarwindpy.plotting` (branch `update-2025`)
+
+Overview
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+- `subplots(nrows, ncols, scale_width, scale_height, **kwargs)` scales figure
+  size with grid shape.
+
+- `save(fig, spath, add_info, log, pdf, png, **kwargs)` writes `.pdf` and `.png`
+  files, adds timestamp text, and supports optional logging.
+
+- `joint_legend(*axes, idx_for_legend, **kwargs)` merges legend entries without
+  duplicates and sorts them.
+
+- `multipanel_figure_shared_cbar(...)` (if present) creates grid with shared
+  colorbar.
+
+  correct figsize
+  files
+
+  colorbar correctly
+
+______________________________________________________________________
+
+## 🔧 Framework & Dependencies
+
+None
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Test `subplots(2,2,scale_width=1.5,scale_height=0.5)` returns 2×2 axes with
+- [ ] Test `save(fig, path, pdf=True,png=True)` writes both `.pdf` and `.png`
+- [ ] Test PNG version includes timestamp text
+- [ ] Test `save(..., log=False)` skips logging calls
+- [ ] Test `joint_legend(ax1,ax2)` merges legend entries, no duplicates, sorted
+- [ ] (If present) Test `multipanel_figure_shared_cbar(...)` arranges shared
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/6-select_data_from_figurepy.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/6-select_data_from_figurepy.md
@@ -1,0 +1,100 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+Combined Test Plan for `solarwindpy.plotting` (branch `update-2025`)
+
+Overview
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+#### Class `SelectFromPlot2D`
+
+- `__init__(plotter, ax, has_colorbar, xdate, ydate, text_kwargs)`.
+
+- Properties: `ax`, `corners`, `date_axes`, `is_multipanel`, `selector`, `text`,
+  and more.
+
+- `_init_corners`, `_add_corners`, `_finalize_text`, `_update_text` manage
+  corner selection and text updates.
+
+- `disconnect(other, scatter_kwargs, **kwargs)` calls `sample_data`,
+  `scatter_sample`, and `plot_failed_samples`.
+
+- `onselect(press, release)` adds patch, updates corners and text.
+
+- `set_ax(ax, has_colorbar)`, `start_text`, `start_selector`, `sample_data(n, random_state)`; `sample_data(frac=…)` raises `NotImplementedError`.
+
+  corners/text
+  `plot_failed_samples()`, disconnects events
+
+______________________________________________________________________
+
+## 🔧 Framework & Dependencies
+
+None
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Test `__init__(plotter,ax)` initializes selector and text objects
+- [ ] Verify `.ax`, `.corners`, `.date_axes`, `.is_multipanel` props
+- [ ] Verify `.selector` property exposes selector object
+- [ ] Verify `.text` property exposes text annotation
+- [ ] Test `_init_corners()` initializes corner coordinates
+- [ ] Test `_add_corners()` appends new corner tuples
+- [ ] Test `_finalize_text()` formats final selection text
+- [ ] Test `_update_text()` formats bounding-box extents
+- [ ] Test `onselect(press,release)` adds rectangle patch and updates
+- [ ] Test `disconnect()` calls `sample_data()`, `scatter_sample()`,
+- [ ] Test `set_ax(ax, has_colorbar)` updates axis and colorbar state
+- [ ] Test `start_text()` initializes the annotation text object
+- [ ] Test `start_selector()` starts selection widget
+- [ ] Test `sample_data(n=3,random_state=…)` returns correct sampled indices
+- [ ] Verify `sample_data(frac=0.1)` raises `NotImplementedError`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/7-labels-basepy.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/7-labels-basepy.md
@@ -1,0 +1,74 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+Combined Test Plan for `solarwindpy.plotting` (branch `update-2025`)
+
+Overview
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+- Namedtuples: `LogAxes`, `AxesLabels`, `RangeLimits` with defaults and custom
+  values.
+
+- Class `Base`: shared logic with `plotting/base`.
+
+  defaults
+
+______________________________________________________________________
+
+## 🔧 Framework & Dependencies
+
+None
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Verify `LogAxes`, `AxesLabels`, `RangeLimits` namedtuples have correct
+- [ ] (Shared with plotting/base) Repeat `Base` tests if context differs
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/8-labels-specialpy.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/8-labels-specialpy.md
@@ -1,0 +1,94 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+Combined Test Plan for `solarwindpy.plotting` (branch `update-2025`)
+
+Overview
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+#### Abstract `ArbitraryLabel(Base)`
+
+- Cannot instantiate; subclass must implement `__str__`.
+
+#### `ManualLabel(tex, unit, path=None)`
+
+- `set_tex` and `set_unit` strip `$` and map units via `base._inU`.
+- `__str__` and `path` manage default vs. custom paths.
+
+#### Prebuilt labels
+
+- `Vsw`, `CarringtonRotation(short_label)`, `Count(norm)`, `Power`,
+  `Probability(other_label, comparison)` verify `tex`, `units`, `path`, and
+  error on invalid input.
+
+  `tex`,`units`,`path`
+  `AssertionError`
+
+______________________________________________________________________
+
+## 🔧 Framework & Dependencies
+
+None
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Verify instantiating `ArbitraryLabel` directly raises `TypeError`
+- [ ] Test `set_tex('$X$')` strips dollar signs
+- [ ] Test `set_unit('km')` maps via `base._inU`
+- [ ] Verify `__str__` formats `tex` and `unit` correctly
+- [ ] Verify `.path` property returns default (from `tex`) and custom path
+- [ ] Verify `Vsw.tex`, `Vsw.units`, `Vsw.path`
+- [ ] Test `CarringtonRotation(short_label=False)` toggles `tex` output
+- [ ] Test `Count(norm='d')` builds `tex` and `path` for density norm
+- [ ] Test `Count(norm=None)` builds default count label
+- [ ] Verify `Power` and `Probability(other_label,comparison)` produce correct
+- [ ] Verify invalid `other_label` or `comparison` in `Probability` raises
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/9-Fixtures-and-Utilities.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/9-Fixtures-and-Utilities.md
@@ -1,0 +1,78 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+Combined Test Plan for `solarwindpy.plotting` (branch `update-2025`)
+
+Overview
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+- `pytest` fixtures: dummy `Series`, `DataFrame`, `IntervalIndex`, `Axes` from
+  `plt.subplots()`.
+- `tmp_path` for file I/O.
+- Parameterized tests across modes and combinations.
+
+### Justification
+
+- Ensures correct functionality, edge-case handling, API stability, and protects
+  non-public internals.
+
+## 🔧 Framework & Dependencies
+
+- pytest
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Create dummy `Series` fixture for tests
+- [ ] Create dummy `DataFrame` fixture for tests
+- [ ] Create dummy `IntervalIndex` fixture for tests
+- [ ] Use `tmp_path` fixture for file I/O tests
+- [ ] Parameterize tests across modes and combinations
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity/1-Package-Entry-Point-__init__py.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity/1-Package-Entry-Point-__init__py.md
@@ -1,0 +1,97 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_solar_activity.md
+
+## 🧠 Context
+
+Combined Test Plan and Checklist for `solar_activity` Submodule (update-2025 branch)
+
+Overview
+
+This document describes a comprehensive test suite for the **solar_activity** submodule of
+SolarWindPy. The goals are to verify behavior, mock external interactions, and isolate side effects.
+
+Checklist
+
+- [ ] Use `pytest` and `unittest.mock` to verify classes, methods, and properties
+- [ ] Mock external I/O such as HTTP downloads and file reads
+- [ ] Use fixtures (`tmp_path`, `monkeypatch`) to isolate side effects
+
+______________________________________________________________________
+
+Test Framework & Dependencies
+
+- `pytest`
+- `unittest.mock` (for HTTP and filesystem mocking)
+- `pytest-monkeypatch` (monkeypatch fixture)
+- `tmp_path` fixture (built into `pytest` for temporary directories)
+
+Checklist
+
+- [ ] Ensure `pytest` is available
+- [ ] Ensure `unittest.mock` is available for HTTP and filesystem mocking
+- [ ] Ensure `pytest-monkeypatch` plugin is available
+- [ ] Ensure `tmp_path` fixture from core `pytest` is available
+
+______________________________________________________________________
+
+Fixtures
+
+| Fixture | Purpose |
+| ----------------- | -------------------------------------------- |
+| `tmp_path` | Simulate `data_path` directories & files |
+| `monkeypatch` | Patch network calls (e.g., `urllib.request`) |
+| custom DataFrames | Provide synthetic time series inputs |
+
+Checklist
+
+- [ ] Use `tmp_path` to simulate `data_path` directories & files
+- [ ] Use `monkeypatch` to patch network calls such as `urllib.request`
+- [ ] Use custom DataFrames for synthetic time series inputs
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+#### 1.1 `get_all_indices()`
+
+**Purpose:** Ensure it aggregates daily Lα, CaK, SSN, MgII into one DataFrame.
+
+##### Checklist
+
+______________________________________________________________________
+
+## 🔧 Framework & Dependencies
+
+- pytest
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Create dummy classes `DummyLISIRD`, `DummySIDC` with `.data` attributes
+- [ ] Monkeypatch `lisird.lisird.LISIRD` and `sunspot_number.sidc.SIDC` to return dummies
+- [ ] Call `get_all_indices()` and assert columns are `["CaK", "Lalpha", "MgII", "ssn"]`
+- [ ] Call `get_all_indices()` and assert index type is `pd.DatetimeIndex`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity/2-Core-Base-Classes-basepy.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity/2-Core-Base-Classes-basepy.md
@@ -1,0 +1,132 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_solar_activity.md
+
+## 🧠 Context
+
+Combined Test Plan and Checklist for `solar_activity` Submodule (update-2025 branch)
+
+Overview
+
+This document describes a comprehensive test suite for the **solar_activity** submodule of
+SolarWindPy. The goals are to verify behavior, mock external interactions, and isolate side effects.
+
+Checklist
+
+- [ ] Use `pytest` and `unittest.mock` to verify classes, methods, and properties
+- [ ] Mock external I/O such as HTTP downloads and file reads
+- [ ] Use fixtures (`tmp_path`, `monkeypatch`) to isolate side effects
+
+______________________________________________________________________
+
+Test Framework & Dependencies
+
+- `pytest`
+- `unittest.mock` (for HTTP and filesystem mocking)
+- `pytest-monkeypatch` (monkeypatch fixture)
+- `tmp_path` fixture (built into `pytest` for temporary directories)
+
+Checklist
+
+- [ ] Ensure `pytest` is available
+- [ ] Ensure `unittest.mock` is available for HTTP and filesystem mocking
+- [ ] Ensure `pytest-monkeypatch` plugin is available
+- [ ] Ensure `tmp_path` fixture from core `pytest` is available
+
+______________________________________________________________________
+
+Fixtures
+
+| Fixture | Purpose |
+| ----------------- | -------------------------------------------- |
+| `tmp_path` | Simulate `data_path` directories & files |
+| `monkeypatch` | Patch network calls (e.g., `urllib.request`) |
+| custom DataFrames | Provide synthetic time series inputs |
+
+Checklist
+
+- [ ] Use `tmp_path` to simulate `data_path` directories & files
+- [ ] Use `monkeypatch` to patch network calls such as `urllib.request`
+- [ ] Use custom DataFrames for synthetic time series inputs
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+#### 2.1 `class Base`
+
+##### Checklist
+
+#### 2.2 `class ID`
+
+##### Checklist
+
+#### 2.3 `class DataLoader`
+
+##### Checklist
+
+`maybe_update_stale_data`
+
+#### 2.4 `class ActivityIndicator`
+
+##### Checklist
+
+`loader`
+
+#### 2.5 `class IndicatorExtrema`
+
+##### Checklist
+
+______________________________________________________________________
+
+## 🔧 Framework & Dependencies
+
+- pytest
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Instantiate a trivial subclass of `Base` and call `_init_logger()`
+- [ ] Assert `instance.logger` is a `logging.Logger` named correctly
+- [ ] Assert `str(instance) == ClassName`
+- [ ] Create a dummy subclass defining `_url_base` and `_trans_url`
+- [ ] Call `set_key(valid_key)`, assert `instance.key` and `instance.url` match expected
+- [ ] Call `set_key(invalid_key)`, assert `NotImplementedError` is raised
+- [ ] Use `tmp_path` to create fake date-named CSV directories for `get_data_ctime`
+- [ ] Assert `ctime` is parsed correctly or defaults to epoch when none exist
+- [ ] After setting `_ctime`, call and assert `age` = `(today – ctime)` for `get_data_age`
+- [ ] Patch `download_data` and monkeypatch “today” to simulate stale data for
+- [ ] Assert `download_data` called with correct paths in `maybe_update_stale_data`
+- [ ] Create a fake CSV in `data_path/today.csv`, write sample CSV for `load_data`
+- [ ] Call `load_data()` and assert `instance.data` matches DataFrame
+- [ ] Use a dummy subclass implementing abstract methods to test setting and retrieving `id` and
+- [ ] Access `data`, raising on `norm_by` if not set
+- [ ] Test basic interpolation on simple time series (e.g., linear)
+- [ ] Feed synthetic extrema DataFrame (two cycles) into a dummy subclass
+- [ ] Assert `cycle_intervals` yields correct intervals
+- [ ] Test `cut_spec_by_interval()` with valid/invalid `kind`
+- [ ] Test `calculate_extrema_bands()` for single & pair durations
+- [ ] Test `cut_about_extrema_bands()` verifying intervals and labels
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity/3-Plotting-Helpers-plotspy.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity/3-Plotting-Helpers-plotspy.md
@@ -1,0 +1,103 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_solar_activity.md
+
+## 🧠 Context
+
+Combined Test Plan and Checklist for `solar_activity` Submodule (update-2025 branch)
+
+Overview
+
+This document describes a comprehensive test suite for the **solar_activity** submodule of
+SolarWindPy. The goals are to verify behavior, mock external interactions, and isolate side effects.
+
+Checklist
+
+- [ ] Use `pytest` and `unittest.mock` to verify classes, methods, and properties
+- [ ] Mock external I/O such as HTTP downloads and file reads
+- [ ] Use fixtures (`tmp_path`, `monkeypatch`) to isolate side effects
+
+______________________________________________________________________
+
+Test Framework & Dependencies
+
+- `pytest`
+- `unittest.mock` (for HTTP and filesystem mocking)
+- `pytest-monkeypatch` (monkeypatch fixture)
+- `tmp_path` fixture (built into `pytest` for temporary directories)
+
+Checklist
+
+- [ ] Ensure `pytest` is available
+- [ ] Ensure `unittest.mock` is available for HTTP and filesystem mocking
+- [ ] Ensure `pytest-monkeypatch` plugin is available
+- [ ] Ensure `tmp_path` fixture from core `pytest` is available
+
+______________________________________________________________________
+
+Fixtures
+
+| Fixture | Purpose |
+| ----------------- | -------------------------------------------- |
+| `tmp_path` | Simulate `data_path` directories & files |
+| `monkeypatch` | Patch network calls (e.g., `urllib.request`) |
+| custom DataFrames | Provide synthetic time series inputs |
+
+Checklist
+
+- [ ] Use `tmp_path` to simulate `data_path` directories & files
+- [ ] Use `monkeypatch` to patch network calls such as `urllib.request`
+- [ ] Use custom DataFrames for synthetic time series inputs
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+#### 3.1 `class IndicatorPlot`
+
+##### Checklist
+
+numeric X and correct Y
+
+#### 3.2 `class SSNPlot`
+
+##### Checklist
+
+______________________________________________________________________
+
+## 🔧 Framework & Dependencies
+
+- pytest
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Create a dummy `ActivityIndicator` with known `data`
+- [ ] Instantiate `IndicatorPlot(dummy, "col", plasma_index)`, assert `.plot_data` slicing
+- [ ] Patch a matplotlib `Axes` object; call `make_plot(ax)` and assert `ax.plot` called with
+- [ ] Patch a matplotlib `Axes` object; assert `_format_axis` settings are applied
+- [ ] Assert `ykey == "ssn"`
+- [ ] After plotting, verify `ax.set_ylim(0, 200)` was called
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity/4-LISIRD-Sub-package.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity/4-LISIRD-Sub-package.md
@@ -1,0 +1,116 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_solar_activity.md
+
+## 🧠 Context
+
+Combined Test Plan and Checklist for `solar_activity` Submodule (update-2025 branch)
+
+Overview
+
+This document describes a comprehensive test suite for the **solar_activity** submodule of
+SolarWindPy. The goals are to verify behavior, mock external interactions, and isolate side effects.
+
+Checklist
+
+- [ ] Use `pytest` and `unittest.mock` to verify classes, methods, and properties
+- [ ] Mock external I/O such as HTTP downloads and file reads
+- [ ] Use fixtures (`tmp_path`, `monkeypatch`) to isolate side effects
+
+______________________________________________________________________
+
+Test Framework & Dependencies
+
+- `pytest`
+- `unittest.mock` (for HTTP and filesystem mocking)
+- `pytest-monkeypatch` (monkeypatch fixture)
+- `tmp_path` fixture (built into `pytest` for temporary directories)
+
+Checklist
+
+- [ ] Ensure `pytest` is available
+- [ ] Ensure `unittest.mock` is available for HTTP and filesystem mocking
+- [ ] Ensure `pytest-monkeypatch` plugin is available
+- [ ] Ensure `tmp_path` fixture from core `pytest` is available
+
+______________________________________________________________________
+
+Fixtures
+
+| Fixture | Purpose |
+| ----------------- | -------------------------------------------- |
+| `tmp_path` | Simulate `data_path` directories & files |
+| `monkeypatch` | Patch network calls (e.g., `urllib.request`) |
+| custom DataFrames | Provide synthetic time series inputs |
+
+Checklist
+
+- [ ] Use `tmp_path` to simulate `data_path` directories & files
+- [ ] Use `monkeypatch` to patch network calls such as `urllib.request`
+- [ ] Use custom DataFrames for synthetic time series inputs
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+#### 4.1 `class LISIRD_ID`
+
+##### Checklist
+
+#### 4.2 `class LISIRDLoader`
+
+##### Checklist
+
+#### 4.3 `class LISIRD`
+
+##### Checklist
+
+#### 4.4 `class LISIRDExtrema`
+
+##### Checklist
+
+______________________________________________________________________
+
+## 🔧 Framework & Dependencies
+
+- pytest
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Valid keys build URLs
+- [ ] Invalid keys raise error
+- [ ] For `"Lalpha"`, unequal missing values in `convert_nans` raise `NotImplementedError`
+- [ ] For other keys, `convert_nans` is a no-op
+- [ ] DataFrame with duplicated `milliseconds` dropped in `verify_monotonic_epoch`
+- [ ] Manual timestamps dropped for `"f107-penticton"` in `verify_monotonic_epoch`
+- [ ] Mock `urllib.request.urlopen` to return JSON; assert CSV & JSON outputs in `download_data`
+- [ ] Fake CSV & JSON in `data_path/today.*`, assert `loader.data` & `loader.meta` in `load_data`
+- [ ] Monkeypatch loader to return dummy data
+- [ ] Assert `normalized` behavior
+- [ ] Assert `run_normalization` behavior
+- [ ] Assert `interpolate_data()` behavior
+- [ ] Monkeypatch `ExtremaCalculator` to return known `formatted_extrema`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity/5-Extrema-Calculator.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity/5-Extrema-Calculator.md
@@ -1,0 +1,101 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_solar_activity.md
+
+## 🧠 Context
+
+Combined Test Plan and Checklist for `solar_activity` Submodule (update-2025 branch)
+
+Overview
+
+This document describes a comprehensive test suite for the **solar_activity** submodule of
+SolarWindPy. The goals are to verify behavior, mock external interactions, and isolate side effects.
+
+Checklist
+
+- [ ] Use `pytest` and `unittest.mock` to verify classes, methods, and properties
+- [ ] Mock external I/O such as HTTP downloads and file reads
+- [ ] Use fixtures (`tmp_path`, `monkeypatch`) to isolate side effects
+
+______________________________________________________________________
+
+Test Framework & Dependencies
+
+- `pytest`
+- `unittest.mock` (for HTTP and filesystem mocking)
+- `pytest-monkeypatch` (monkeypatch fixture)
+- `tmp_path` fixture (built into `pytest` for temporary directories)
+
+Checklist
+
+- [ ] Ensure `pytest` is available
+- [ ] Ensure `unittest.mock` is available for HTTP and filesystem mocking
+- [ ] Ensure `pytest-monkeypatch` plugin is available
+- [ ] Ensure `tmp_path` fixture from core `pytest` is available
+
+______________________________________________________________________
+
+Fixtures
+
+| Fixture | Purpose |
+| ----------------- | -------------------------------------------- |
+| `tmp_path` | Simulate `data_path` directories & files |
+| `monkeypatch` | Patch network calls (e.g., `urllib.request`) |
+| custom DataFrames | Provide synthetic time series inputs |
+
+Checklist
+
+- [ ] Use `tmp_path` to simulate `data_path` directories & files
+- [ ] Use `monkeypatch` to patch network calls such as `urllib.request`
+- [ ] Use custom DataFrames for synthetic time series inputs
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+#### 5.1 `class ExtremaCalculator`
+
+##### Checklist
+
+______________________________________________________________________
+
+## 🔧 Framework & Dependencies
+
+- pytest
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] `set_name`: invalid names raise `ValueError`
+- [ ] `set_data`: handle window and data shift
+- [ ] `set_threshold`: callable vs scalar
+- [ ] `find_threshold_crossings`: correct crossing indices
+- [ ] `cut_data_into_extrema_finding_intervals`: correct binning
+- [ ] `_find_extrema` logic
+- [ ] `_validate_extrema` logic
+- [ ] `format_extrema` logic
+- [ ] `find_extrema` logic
+- [ ] `make_plot`: conditional plotting
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None

--- a/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity/6-Sunspot-Number-Sub-package.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_solar_activity/6-Sunspot-Number-Sub-package.md
@@ -1,0 +1,140 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_solar_activity.md
+
+## 🧠 Context
+
+Combined Test Plan and Checklist for `solar_activity` Submodule (update-2025 branch)
+
+Overview
+
+This document describes a comprehensive test suite for the **solar_activity** submodule of
+SolarWindPy. The goals are to verify behavior, mock external interactions, and isolate side effects.
+
+Checklist
+
+- [ ] Use `pytest` and `unittest.mock` to verify classes, methods, and properties
+- [ ] Mock external I/O such as HTTP downloads and file reads
+- [ ] Use fixtures (`tmp_path`, `monkeypatch`) to isolate side effects
+
+______________________________________________________________________
+
+Test Framework & Dependencies
+
+- `pytest`
+- `unittest.mock` (for HTTP and filesystem mocking)
+- `pytest-monkeypatch` (monkeypatch fixture)
+- `tmp_path` fixture (built into `pytest` for temporary directories)
+
+Checklist
+
+- [ ] Ensure `pytest` is available
+- [ ] Ensure `unittest.mock` is available for HTTP and filesystem mocking
+- [ ] Ensure `pytest-monkeypatch` plugin is available
+- [ ] Ensure `tmp_path` fixture from core `pytest` is available
+
+______________________________________________________________________
+
+Fixtures
+
+| Fixture | Purpose |
+| ----------------- | -------------------------------------------- |
+| `tmp_path` | Simulate `data_path` directories & files |
+| `monkeypatch` | Patch network calls (e.g., `urllib.request`) |
+| custom DataFrames | Provide synthetic time series inputs |
+
+Checklist
+
+- [ ] Use `tmp_path` to simulate `data_path` directories & files
+- [ ] Use `monkeypatch` to patch network calls such as `urllib.request`
+- [ ] Use custom DataFrames for synthetic time series inputs
+
+______________________________________________________________________
+
+## 🎯 Overview of the Task
+
+#### 6.1 `class SIDC_ID`
+
+##### Checklist
+
+#### 6.2 `class SIDCLoader`
+
+##### Checklist
+
+#### 6.3 `class SIDC`
+
+##### Checklist
+
+#### 6.4 `class SSNExtrema`
+
+##### Checklist
+
+______________________________________________________________________
+
+### Test File Structure
+
+```
+tests/
+  solar_activity/
+    test_init.py
+    test_base.py
+    test_plots.py
+    lisird/
+      test_lisird_id.py
+      test_lisird_loader.py
+      test_lisird.py
+      test_extrema_calculator.py
+    sunspot_number/
+      test_sidc_id.py
+      test_sidc_loader.py
+      test_sidc.py
+      test_ssnextrema.py
+```
+
+## 🔧 Framework & Dependencies
+
+- pytest
+
+## 📂 Affected Files and Paths
+
+None
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Valid keys build URLs
+- [ ] Invalid keys raise error
+- [ ] `convert_nans`: replace `-1` with `np.nan`
+- [ ] `download_data`: mock `pd.read_csv`; assert CSV is created
+- [ ] `load_data`: verify `cycle` column is produced
+- [ ] Init with dummy loader & `SSNExtrema`
+- [ ] Test `calculate_extrema_kind`
+- [ ] Test `calculate_edge`
+- [ ] Test `normalized`
+- [ ] Test `run_normalization`
+- [ ] Test `cut_spec_by_ssn_band`
+- [ ] Test `interpolate_data`
+- [ ] Test `plot_on_colorbar`
+- [ ] Temporary `ssn_extrema.csv`, assert parsed `data`
+- [ ] Passing args/kwargs raises `ValueError`
+- [ ] Mirror the test file structure as described above
+- [ ] Add this plan as `solar_activity_TEST_PLAN.md` at the root of the `solar_activity` module
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+None


### PR DESCRIPTION
## Summary
- decompose combined documentation plan into section-specific markdown templates
- decompose fitfunctions test plan into fixture and module sections
- decompose plotting and solar activity test plans into per-module task files

## Testing
- `python -m flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68901addba64832c90b9afedfc8b15af