### PR TITLE
docs: split combined documentation plan into section files

### DIFF
--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/1-Overview-and-Goals.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/1-Overview-and-Goals.md
@@ -1,0 +1,50 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+This section outlines the overarching aims and scope for SolarWindPy's documentation effort.
+
+## 🎯 Overview of the Task
+
+- Aim: Provide clear, searchable, and versioned API documentation and tutorials.
+- Scope:
+  - Auto-generated API reference for all modules and subpackages.
+  - User guide with installation, basic usage, and advanced examples.
+  - Hosted primarily on Read the Docs and mirrored on GitHub Pages.
+
+## 🔧 Framework & Dependencies
+
+N/A
+
+## 📂 Affected Files and Paths
+
+N/A
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+N/A
+
+## ✅ Acceptance Criteria
+
+- [ ] Provide clear, searchable, and versioned API documentation and tutorials.
+- [ ] Auto-generate API reference for all modules and subpackages.
+- [ ] Offer a user guide with installation, basic usage, and advanced examples.
+- [ ] Host documentation on Read the Docs and mirror it on GitHub Pages.
+
+## 🧩 Decomposition Instructions (Optional)
+
+N/A
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+N/A
+
+## 💬 Additional Notes
+
+N/A

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/2-Toolchain-and-Hosting.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/2-Toolchain-and-Hosting.md
@@ -1,0 +1,65 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+Defines the tools and hosting strategy for building and publishing documentation.
+
+## 🎯 Overview of the Task
+
+- Documentation generator: Sphinx
+  - Extensions: `sphinx.ext.autodoc`, `sphinx.ext.napoleon`, `sphinx.ext.mathjax`,
+    `sphinx.ext.viewcode`, `sphinx.ext.githubpages`.
+  - Theme: `sphinx_rtd_theme`.
+- Environment:
+  - `docs/requirements.txt` lists Sphinx and related extensions.
+  - `docs/Makefile` and `docs/make.bat` provide `html`, `clean`, and `spellcheck` targets.
+- Hosting:
+  - Read the Docs for versioned builds.
+  - GitHub Pages via a `gh-pages` branch.
+
+## 🔧 Framework & Dependencies
+
+- Sphinx
+- `sphinx.ext.autodoc`
+- `sphinx.ext.napoleon`
+- `sphinx.ext.mathjax`
+- `sphinx.ext.viewcode`
+- `sphinx.ext.githubpages`
+- `sphinx_rtd_theme`
+
+## 📂 Affected Files and Paths
+
+- `docs/requirements.txt`
+- `docs/Makefile`
+- `docs/make.bat`
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+N/A
+
+## ✅ Acceptance Criteria
+
+- [ ] Evaluate existing docs infrastructure under `docs/` (e.g., Sphinx config, extensions).
+- [ ] Decide to continue with Sphinx versus evaluate alternatives.
+- [ ] Review benefits of plugins such as `sphinx.ext.viewcode` and `sphinx.ext.githubpages`.
+- [ ] Create `docs/requirements.txt` listing Sphinx and related extensions.
+- [ ] Update `docs/Makefile` and `docs/make.bat` to include `html`, `clean`, and `spellcheck`
+  targets.
+
+## 🧩 Decomposition Instructions (Optional)
+
+N/A
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+N/A
+
+## 💬 Additional Notes
+
+N/A

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/3-Repository-Structure.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/3-Repository-Structure.md
@@ -1,0 +1,60 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+Provides the repository layout relevant to documentation.
+
+```
+SolarWindPy/
+├── docs/
+│   ├── source/
+│   │   ├── conf.py
+│   │   ├── index.rst
+│   │   ├── modules.rst
+│   │   └── tutorial/
+│   │       └── quickstart.rst
+│   └── Makefile
+├── solarwindpy/
+│   └── ... (code packages)
+└── plans/combined_plan_with_checklist_documentation.md
+```
+
+## 🎯 Overview of the Task
+
+Summarize and maintain the structure shown above to support documentation development.
+
+## 🔧 Framework & Dependencies
+
+N/A
+
+## 📂 Affected Files and Paths
+
+- `docs/`
+- `solarwindpy/`
+- `plans/combined_plan_with_checklist_documentation.md`
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+N/A
+
+## ✅ Acceptance Criteria
+
+N/A
+
+## 🧩 Decomposition Instructions (Optional)
+
+N/A
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+N/A
+
+## 💬 Additional Notes
+
+N/A

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/4-Configuration-and-Standards.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/4-Configuration-and-Standards.md
@@ -1,0 +1,68 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+Sets configuration choices and documentation standards for the project.
+
+## 🎯 Overview of the Task
+
+- Update `docs/source/conf.py`:
+  - Add Napoleon extension and enable `autosummary_generate = True`.
+  - Confirm `html_theme = "sphinx_rtd_theme"`.
+  - Ensure `flake8-docstrings` rules D205/D406 are enabled.
+  - Retrieve `version` from package metadata instead of hardcoding it.
+- Standardize docstrings to NumPy style across the codebase.
+  - Include `Parameters`, `Returns`, `Raises`, and `Examples` sections.
+  - Audit modules (`core/`, `fitfunctions/`, `instabilities/`, `plotting/`, etc.) for missing or
+    incomplete docstrings.
+
+## 🔧 Framework & Dependencies
+
+- `sphinx.ext.napoleon`
+- `flake8-docstrings`
+- `sphinx_rtd_theme`
+
+## 📂 Affected Files and Paths
+
+- `docs/source/conf.py`
+- `setup.cfg`
+- `core/`
+- `fitfunctions/`
+- `instabilities/`
+- `plotting/`
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+N/A
+
+## ✅ Acceptance Criteria
+
+- [ ] Verify that `docs/source/conf.py` loads `autodoc`, `todo`, `mathjax`, `viewcode`, and
+  `githubpages`.
+- [ ] Retrieve package `version` dynamically in `docs/source/conf.py`.
+- [ ] Confirm that the theme `sphinx_rtd_theme` is set appropriately.
+- [ ] Check that the source file suffix is `.rst` and master doc is `index.rst`.
+- [ ] Add `sphinx.ext.napoleon` extension to parse NumPy/Google-style docstrings.
+- [ ] Audit all public modules and classes for missing docstrings.
+- [ ] Standardize all existing docstrings to NumPy style.
+- [ ] Add missing sections such as `Examples`, `Notes`, and `Attributes` where relevant.
+- [ ] Remove or address any `TODO` placeholders related to documentation.
+- [ ] Ensure `flake8-docstrings` rules D205/D406 are enabled in `setup.cfg`.
+
+## 🧩 Decomposition Instructions (Optional)
+
+N/A
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+N/A
+
+## 💬 Additional Notes
+
+N/A

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/5-Documentation-Content.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/5-Documentation-Content.md
@@ -1,0 +1,61 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+Outlines the content to include in the documentation set.
+
+## 🎯 Overview of the Task
+
+- Create `docs/source/modules.rst` with a toctree covering core modules.
+- Update `docs/source/index.rst` to reference:
+  - `installation.rst`
+  - `usage.rst`
+  - `tutorial.rst`
+  - `api_reference.rst`
+- Add tutorial pages such as `docs/source/tutorial/quickstart.rst` for installation and basic
+  workflow.
+- Generate API reference pages with `sphinx-apidoc` and `autosummary`.
+
+## 🔧 Framework & Dependencies
+
+- `sphinx-apidoc`
+- `autosummary`
+
+## 📂 Affected Files and Paths
+
+- `docs/source/modules.rst`
+- `docs/source/index.rst`
+- `docs/source/tutorial/quickstart.rst`
+- `api_reference.rst`
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+N/A
+
+## ✅ Acceptance Criteria
+
+- [ ] Update `docs/source/index.rst` to include `installation.rst`, `usage.rst`, `tutorial.rst`, and
+  `api_reference.rst`.
+- [ ] Create `installation.rst` with installation instructions (pip, conda).
+- [ ] Create `usage.rst` with basic usage examples.
+- [ ] Create `tutorial.rst` with a step-by-step tutorial.
+- [ ] Generate API reference via `sphinx-apidoc` and include in `api_reference.rst`.
+- [ ] Run `sphinx-apidoc` to regenerate module stub files.
+
+## 🧩 Decomposition Instructions (Optional)
+
+N/A
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+N/A
+
+## 💬 Additional Notes
+
+N/A

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/6-CI-CD-and-Validation.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/6-CI-CD-and-Validation.md
@@ -1,0 +1,56 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+Details the continuous integration and validation steps for documentation.
+
+## 🎯 Overview of the Task
+
+- Add CI workflow `.github/workflows/doc-build.yml` to build documentation and fail on warnings.
+- Use GitHub Actions to deploy to `gh-pages`.
+- Configure Read the Docs with `.readthedocs.yaml`.
+- Validate locally by running `sphinx-apidoc` and `make html` without errors or warnings and testing
+  links and snippets.
+
+## 🔧 Framework & Dependencies
+
+- GitHub Actions
+- `sphinx-apidoc`
+- `make html`
+
+## 📂 Affected Files and Paths
+
+- `.github/workflows/doc-build.yml`
+- `.github/workflows/deploy-docs.yml`
+- `.readthedocs.yaml`
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+N/A
+
+## ✅ Acceptance Criteria
+
+- [ ] Add CI workflow `.github/workflows/doc-build.yml` to install docs requirements and run
+  `make html`.
+- [ ] Execute `make html` in `docs/` and confirm no errors or warnings.
+- [ ] Test links, code snippets, and formatting in the generated site.
+- [ ] Configure Read the Docs with `.readthedocs.yaml`.
+- [ ] Create `.github/workflows/deploy-docs.yml` to build and push to `gh-pages`.
+
+## 🧩 Decomposition Instructions (Optional)
+
+N/A
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+N/A
+
+## 💬 Additional Notes
+
+N/A

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/7-Maintenance.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/7-Maintenance.md
@@ -1,0 +1,54 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_plan_with_checklist_documentation.md
+
+## 🧠 Context
+
+Covers long-term maintenance practices for documentation.
+
+## 🎯 Overview of the Task
+
+- Integrate `doc8` or similar tools for RST linting.
+- Add docstring conventions and workflow guidelines to `CONTRIBUTING.md`.
+- Create a pull request template that reminds contributors to update docstrings.
+- Include a documentation badge in `README.rst`.
+- Schedule periodic reviews of documentation coverage.
+
+## 🔧 Framework & Dependencies
+
+- `doc8`
+- `flake8-docstrings`
+
+## 📂 Affected Files and Paths
+
+- `CONTRIBUTING.md`
+- `README.rst`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+N/A
+
+## ✅ Acceptance Criteria
+
+- [ ] Add a documentation badge to `README.rst`.
+- [ ] Document docstring conventions and update workflow in `CONTRIBUTING.md`.
+- [ ] Set up linting for documentation (e.g., `flake8-docstrings`, `rst-lint`, `doc8`) in CI.
+- [ ] Schedule periodic review of documentation coverage.
+- [ ] Create `.github/PULL_REQUEST_TEMPLATE.md` to prompt docstring updates.
+
+## 🧩 Decomposition Instructions (Optional)
+
+N/A
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+N/A
+
+## 💬 Additional Notes
+
+N/A


### PR DESCRIPTION
## Summary
- split `combined_plan_with_checklist_documentation.md` into section-specific plan files following the SweepAI task template
- document toolchain, configuration, content, CI/CD, and maintenance steps for SolarWindPy docs

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890566d9f58832ca67a5b0ccf1d8f25