### PR TITLE
docs: decompose fitfunctions plan

### DIFF
--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/1-Common-fixtures.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/1-Common-fixtures.md
@@ -1,0 +1,59 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Verify correctness, robustness, and coverage of the `solarwindpy.fitfunctions` submodule. This task focuses on shared fixtures used across tests. Testing uses `pytest` with fixtures and adheres to `AGENTS.md` guidelines (`pytest -q`, no skipping, style with `flake8` and `black`).
+
+## 🎯 Overview of the Task
+
+```python
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.optimize import OptimizeResult
+
+from solarwindpy.fitfunctions import core, gaussians, trend_fits, plots, tex_info
+```
+
+- `simple_linear_data`: 1D arrays `x = np.linspace(0, 1, 20)`, `y = 2 * x + 1 + noise`, `w = np.ones_like(x)`.
+- `gauss_data`: sample `x`, generate `y = A · exp(-0.5((x - μ)/σ)²) + noise`.
+- `small_n`: too few points to trigger `sufficient_data -> ValueError`.
+
+## 🔧 Framework & Dependencies
+
+- `pytest`
+- `numpy`
+- `pandas`
+- `scipy`
+
+## 📂 Affected Files and Paths
+
+- `tests/fitfunctions/conftest.py`
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None.
+
+## ✅ Acceptance Criteria
+
+- [ ] Implement `simple_linear_data` fixture.
+- [ ] Implement `gauss_data` fixture.
+- [ ] Implement `small_n` fixture.
+
+## 🧩 Decomposition Instructions (Optional)
+
+None.
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None.
+
+## 💬 Additional Notes
+
+Follow repository style guidelines and run tests with `pytest -q`.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/2-core.py-FitFunction.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/2-core.py-FitFunction.md
@@ -1,0 +1,118 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Verify correctness, robustness, and coverage of the `solarwindpy.fitfunctions` submodule. This task targets the `FitFunction` class in `core.py`.
+
+## 🎯 Overview of the Task
+
+### 2.1 Initialization & observation filtering
+
+- `_clean_raw_obs`
+  - Mismatched shapes → `ValueError`.
+  - Valid inputs → arrays returned.
+- `_build_one_obs_mask`
+  - Test with `xmin`, `xmax`, `None` → masks correct.
+- `_build_outside_mask`
+  - `outside=None` → all `True`.
+  - Valid tuple → only outside points `True`.
+- `set_fit_obs`
+  - Combined masks apply correctly for `x`, `y`, `wmin`, `wmax`, and `logy`.
+
+### 2.2 Argument introspection
+
+- `_set_argnames`
+  - On subclass with known signature → `argnames` matches function arguments.
+
+### 2.3 Fitting workflow
+
+- `_run_least_squares`
+  - Monkey-patch `scipy.optimize.least_squares` to return dummy `OptimizeResult`.
+  - Test default kwargs (`loss`, `method`, etc.).
+  - Passing invalid `args` kwarg → `ValueError`.
+- `_calc_popt_pcov_psigma_chisq`
+  - Feed dummy `res` with known `fun`, `jac`, produce known `popt`, `pcov`, `psigma`, `chisq`.
+- `make_fit`
+  - Success: returns `None`, sets `_popt`, `_psigma`, `_pcov`, `_chisq_dof`, `_fit_result`, builds `TeX_info` and `plotter`.
+  - Insufficient data: returns `ValueError` if `return_exception=True`.
+  - Optimization failure: raises `RuntimeError` or returns exception.
+
+### 2.4 Public properties
+
+- `__str__` → "<ClassName> (\<TeX_function>)".
+- `__call__` → returns `function(x, *popt)` array.
+- Properties:
+  - `argnames`, `fit_bounds`, `chisq_dof`, `dof`, `fit_result`,
+  - `initial_guess_info`, `nobs`, `observations`, `plotter`,
+  - `popt`, `psigma`, `psigma_relative`, `combined_popt_psigma`, `pcov`, `rsq`,
+  - `sufficient_data`, `TeX_info`.
+- Test: after a dummy fit, each property yields expected dtype, shape, or value.
+
+## 🔧 Framework & Dependencies
+
+- `pytest`
+- `scipy`
+- `numpy`
+
+## 📂 Affected Files and Paths
+
+- `solarwindpy/fitfunctions/core.py`
+- `tests/fitfunctions/test_core.py`
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None.
+
+## ✅ Acceptance Criteria
+
+- [ ] Test `_clean_raw_obs` for mismatched shapes (`ValueError`).
+- [ ] Test `_clean_raw_obs` for valid inputs (arrays returned).
+- [ ] Test `_build_one_obs_mask` with `xmin`, `xmax`, `None` (masks correct).
+- [ ] Test `_build_outside_mask` with `outside=None` (all `True`).
+- [ ] Test `_build_outside_mask` with valid tuple (only outside points `True`).
+- [ ] Test `set_fit_obs` for combined masks (`x`, `y`, `wmin`, `wmax`, `logy`).
+- [ ] Test `_set_argnames` on subclass with known signature (`argnames` matches function arguments\`).
+- [ ] Test `_run_least_squares` with monkey-patched optimizer (dummy `OptimizeResult`).
+- [ ] Test `_run_least_squares` for default kwargs (`loss`, `method`, etc.).
+- [ ] Test `_run_least_squares` for invalid `args` kwarg (`ValueError`).
+- [ ] Test `_calc_popt_pcov_psigma_chisq` with dummy `res`, known `fun`, `jac` (check outputs).
+- [ ] Test `make_fit` success path (sets internals and helpers).
+- [ ] Test `make_fit` with insufficient data (`ValueError` if `return_exception=True`).
+- [ ] Test `make_fit` on optimization failure (`RuntimeError` or exception).
+- [ ] Test `__str__` returns "<ClassName> (\<TeX_function>)".
+- [ ] Test `__call__` returns `function(x, *popt)` array.
+- [ ] Test `argnames` property after dummy fit.
+- [ ] Test `fit_bounds` property after dummy fit.
+- [ ] Test `chisq_dof` property after dummy fit.
+- [ ] Test `dof` property after dummy fit.
+- [ ] Test `fit_result` property after dummy fit.
+- [ ] Test `initial_guess_info` property after dummy fit.
+- [ ] Test `nobs` property after dummy fit.
+- [ ] Test `observations` property after dummy fit.
+- [ ] Test `plotter` property after dummy fit.
+- [ ] Test `popt` property after dummy fit.
+- [ ] Test `psigma` property after dummy fit.
+- [ ] Test `psigma_relative` property after dummy fit.
+- [ ] Test `combined_popt_psigma` property after dummy fit.
+- [ ] Test `pcov` property after dummy fit.
+- [ ] Test `rsq` property after dummy fit.
+- [ ] Test `sufficient_data` property after dummy fit.
+- [ ] Test `TeX_info` property after dummy fit.
+
+## 🧩 Decomposition Instructions (Optional)
+
+None.
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None.
+
+## 💬 Additional Notes
+
+Follow repository style guidelines and run tests with `pytest -q`.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/3-gaussians.py-Gaussian-GaussianNormalized-GaussianLn.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/3-gaussians.py-Gaussian-GaussianNormalized-GaussianLn.md
@@ -1,0 +1,69 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Verify correctness, robustness, and coverage of the `solarwindpy.fitfunctions` submodule. This task targets `Gaussian`, `GaussianNormalized`, and `GaussianLn` in `gaussians.py`.
+
+## 🎯 Overview of the Task
+
+For each class:
+
+### 3.1 Signature & `function` property
+
+- Call `.function`, inspect returned callable’s signature and behavior on sample `x`.
+
+### 3.2 `p0` initial guesses
+
+- With synthetic Gaussian data → `p0` ≈ true `[μ, σ, A]` (tolerance).
+- Empty data → triggers the zero-size-array `ValueError`.
+
+### 3.3 `TeX_function`
+
+- Matches expected LaTeX string literal.
+
+### 3.4 `make_fit` override
+
+- On success → calls base `make_fit`, sets `TeX_argnames` in `TeX_info`.
+- On forced failure (monkey-patched optimizer) → no exception in `make_fit`, leaves `TeX_argnames` unset.
+
+## 🔧 Framework & Dependencies
+
+- `pytest`
+- `numpy`
+- `scipy`
+
+## 📂 Affected Files and Paths
+
+- `solarwindpy/fitfunctions/gaussians.py`
+- `tests/fitfunctions/test_gaussians.py`
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None.
+
+## ✅ Acceptance Criteria
+
+- [ ] Test `.function` signature and behavior on sample `x`.
+- [ ] Test `p0` with synthetic Gaussian data (matches true `[μ, σ, A]` within tolerance).
+- [ ] Test `p0` with empty data (triggers zero-size-array `ValueError`).
+- [ ] Test `.TeX_function` matches expected LaTeX string literal.
+- [ ] Test success path: calls base `make_fit`, sets `TeX_argnames` in `TeX_info`.
+- [ ] Test forced failure: no exception in `make_fit`, leaves `TeX_argnames` unset.
+
+## 🧩 Decomposition Instructions (Optional)
+
+None.
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None.
+
+## 💬 Additional Notes
+
+Follow repository style guidelines and run tests with `pytest -q`.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/4-trend_fits.py-TrendFit.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/4-trend_fits.py-TrendFit.md
@@ -1,0 +1,99 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Verify correctness, robustness, and coverage of the `solarwindpy.fitfunctions` submodule. This task targets the `TrendFit` class in `trend_fits.py`.
+
+## 🎯 Overview of the Task
+
+### 4.1 Initialization & type enforcement
+
+- Valid `agged: pd.DataFrame`, `trendfunc: FitFunction` subclass → no error.
+- Invalid `ffunc1d` or `trendfunc` → raises `TypeError`.
+
+### 4.2 Properties
+
+- `__str__`, `agged`, `ffunc1d_class`, `trendfunc_class`, `ffuncs` (after `make_ffunc1ds`),
+  `popt_1d`, `psigma_1d`, `trend_func`, `bad_fits`, `popt1d_keys`, `trend_logx`, `labels`.
+
+### 4.3 1D-fit pipeline
+
+- `make_ffunc1ds`: builds `Series` of `FitFunction` instances.
+- `make_1dfits`: mark bad fits (return value ≠ `None`), remove them from `ffuncs` → `bad_fits` populated.
+
+### 4.4 Trend fitting
+
+- `make_trend_func`: with valid `popt_1d`, builds `trend_func`; insufficient fits → `ValueError`.
+
+### 4.5 Plot helpers
+
+- `plot_all_ffuncs`, `plot_all_popt_1d`, `plot_trend_fit_resid`,
+  `plot_trend_and_resid_on_ffuncs`, `plot_1d_popt_and_trend`
+  - Stub out plotting (monkey-patch `.plotter` methods to record calls), ensure axes returned.
+
+### 4.6 Label sharing
+
+- `set_agged` type check; `set_fitfunctions` logic; `set_shared_labels` updates label objects.
+
+## 🔧 Framework & Dependencies
+
+- `pytest`
+- `pandas`
+- `numpy`
+
+## 📂 Affected Files and Paths
+
+- `solarwindpy/fitfunctions/trend_fits.py`
+- `tests/fitfunctions/test_trend_fits.py`
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None.
+
+## ✅ Acceptance Criteria
+
+- [ ] Test valid `agged: pd.DataFrame` and `trendfunc: FitFunction` subclass (no error).
+- [ ] Test invalid `ffunc1d` or `trendfunc` (raises `TypeError`).
+- [ ] Test `__str__` property.
+- [ ] Test `agged` property.
+- [ ] Test `ffunc1d_class` property.
+- [ ] Test `trendfunc_class` property.
+- [ ] Test `ffuncs` after `make_ffunc1ds`.
+- [ ] Test `popt_1d` property.
+- [ ] Test `psigma_1d` property.
+- [ ] Test `trend_func` property.
+- [ ] Test `bad_fits` property.
+- [ ] Test `popt1d_keys` property.
+- [ ] Test `trend_logx` property.
+- [ ] Test `labels` property.
+- [ ] Test `make_ffunc1ds` builds `Series` of `FitFunction` instances.
+- [ ] Test `make_1dfits` marks bad fits and populates `bad_fits`.
+- [ ] Test `make_trend_func` with valid `popt_1d` (builds `trend_func`).
+- [ ] Test `make_trend_func` with insufficient fits (`ValueError`).
+- [ ] Test `plot_all_ffuncs` helper.
+- [ ] Test `plot_all_popt_1d` helper.
+- [ ] Test `plot_trend_fit_resid` helper.
+- [ ] Test `plot_trend_and_resid_on_ffuncs` helper.
+- [ ] Test `plot_1d_popt_and_trend` helper.
+- [ ] Stub out plotting to record calls and verify axes returned.
+- [ ] Test `set_agged` type check.
+- [ ] Test `set_fitfunctions` logic.
+- [ ] Test `set_shared_labels` updates label objects.
+
+## 🧩 Decomposition Instructions (Optional)
+
+None.
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None.
+
+## 💬 Additional Notes
+
+Follow repository style guidelines and run tests with `pytest -q`.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/5-plots.py-FFPlot.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/5-plots.py-FFPlot.md
@@ -1,0 +1,98 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Verify correctness, robustness, and coverage of the `solarwindpy.fitfunctions` submodule. This task targets the `FFPlot` class in `plots.py`.
+
+## 🎯 Overview of the Task
+
+### 5.1 Initialization & basic attributes
+
+- `__init__` with dummy `Observations`, `y_fit`, `TeXinfo`, dummy `OptimizeResult`, `fitfunction_name` → no errors.
+- `__str__`, `labels`, `log` default `(False, False)`, `observations`, `fitfunction_name`, `fit_result`, `y_fit`.
+
+### 5.2 Path generation
+
+- Vary `labels.x`, `labels.y`, optional `labels.z` → `path` property concatenates correctly.
+
+### 5.3 State mutators
+
+- `set_fitfunction_name`, `set_fit_result`, `set_observations` (shape assertions).
+
+### 5.4 Internal helpers
+
+- `_estimate_markevery` with small and huge `observations.used.x.size`.
+- `_format_hax`, `_format_rax`: stub axes → grid/scale calls, ensure correct axes methods invoked.
+
+### 5.5 Plot methods
+
+- `plot_raw`, `plot_used`, `plot_fit`, `plot_raw_used_fit`, `plot_residuals`, `plot_raw_used_fit_resid`
+  - Provide dummy axes (monkey-patch `plt.subplots`) and assert returned axes and legend/text behavior.
+  - For `pct=True/False`, robust branch, missing `fit_result.fun` → skip second curve.
+
+### 5.6 Label & style setters
+
+- `set_labels` updates `labels` namedtuple, unexpected key → `KeyError`.
+- `set_log` toggles `log` flags.
+- `set_TeX_info` stores `TeXinfo`.
+
+## 🔧 Framework & Dependencies
+
+- `pytest`
+- `matplotlib`
+
+## 📂 Affected Files and Paths
+
+- `solarwindpy/fitfunctions/plots.py`
+- `tests/fitfunctions/test_plots.py`
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None.
+
+## ✅ Acceptance Criteria
+
+- [ ] Test `__init__` with dummy inputs (no errors).
+- [ ] Test `__str__` method.
+- [ ] Test `labels` property.
+- [ ] Test default `log` equals `(False, False)`.
+- [ ] Test `observations` property.
+- [ ] Test `fitfunction_name` property.
+- [ ] Test `fit_result` property.
+- [ ] Test `y_fit` property.
+- [ ] Test `path` concatenation for different label combinations.
+- [ ] Test `set_fitfunction_name`.
+- [ ] Test `set_fit_result`.
+- [ ] Test `set_observations` with shape assertions.
+- [ ] Test `_estimate_markevery` for small and large datasets.
+- [ ] Test `_format_hax` with stub axes.
+- [ ] Test `_format_rax` with stub axes.
+- [ ] Test `plot_raw` method.
+- [ ] Test `plot_used` method.
+- [ ] Test `plot_fit` method.
+- [ ] Test `plot_raw_used_fit` method.
+- [ ] Test `plot_residuals` for kinds `'simple'`, `'robust'`, `'both'`.
+- [ ] Test `plot_raw_used_fit_resid` method.
+- [ ] Provide dummy axes and monkey-patch `plt.subplots`, verify axes and legend/text behavior.
+- [ ] Test `pct=True/False`, robust branch, missing `fit_result.fun` (skip second curve).
+- [ ] Test `set_labels` updates `labels` and raises `KeyError` on unknown key.
+- [ ] Test `set_log` toggles `log` flags.
+- [ ] Test `set_TeX_info` stores `TeXinfo`.
+
+## 🧩 Decomposition Instructions (Optional)
+
+None.
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None.
+
+## 💬 Additional Notes
+
+Follow repository style guidelines and run tests with `pytest -q`.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/6-tex_info.py-TeXinfo.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/6-tex_info.py-TeXinfo.md
@@ -1,0 +1,79 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Verify correctness, robustness, and coverage of the `solarwindpy.fitfunctions` submodule. This task targets the `TeXinfo` class in `tex_info.py`.
+
+## 🎯 Overview of the Task
+
+### 6.1 Construction & storage
+
+- Valid inputs; invalid types → `TypeError` or `ValueError` in setters.
+
+### 6.2 Properties & formatting
+
+- `info` / `__str__` with various flag combinations.
+- Properties: `initial_guess_info`, `chisq_dof`, `npts`, `popt`, `psigma`, `rsq`,
+  `TeX_argnames`, `TeX_function`, `TeX_popt`, `TeX_relative_error`.
+
+### 6.3 Static/private helpers
+
+- `_check_and_add_math_escapes`: odd `$` → `ValueError`.
+- `_calc_precision`, `_simplify_for_paper`, `_add_additional_info`, `_build_fit_parameter_info`,
+  `annotate_info`, `build_info`, setters, `val_uncert_2_string`.
+
+## 🔧 Framework & Dependencies
+
+- `pytest`
+- `numpy`
+
+## 📂 Affected Files and Paths
+
+- `solarwindpy/fitfunctions/tex_info.py`
+- `tests/fitfunctions/test_tex_info.py`
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None.
+
+## ✅ Acceptance Criteria
+
+- [ ] Test valid construction and invalid types in setters (`TypeError`/`ValueError`).
+- [ ] Test `info` / `__str__` with flag combinations.
+- [ ] Test `initial_guess_info` property.
+- [ ] Test `chisq_dof` property.
+- [ ] Test `npts` property.
+- [ ] Test `popt` property.
+- [ ] Test `psigma` property.
+- [ ] Test `rsq` property.
+- [ ] Test `TeX_argnames` property.
+- [ ] Test `TeX_function` property.
+- [ ] Test `TeX_popt` property.
+- [ ] Test `TeX_relative_error` property.
+- [ ] Test `_check_and_add_math_escapes` with odd `$` (`ValueError`).
+- [ ] Test `_calc_precision` (exponent from scientific notation).
+- [ ] Test `_simplify_for_paper` (strips zeros/decimals).
+- [ ] Test `_add_additional_info` with `str`, iterable, invalid type.
+- [ ] Test `_build_fit_parameter_info` (flag combos, unused kwargs `ValueError`).
+- [ ] Test `annotate_info` with stub axis (`ax.text` calls).
+- [ ] Test `build_info` (same as `info` with explicit kwargs).
+- [ ] Test all setters for type/key-consistency errors.
+- [ ] Test `val_uncert_2_string` with value/uncertainty pairs (e.g., `3.1415± 0.01`).
+
+## 🧩 Decomposition Instructions (Optional)
+
+None.
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None.
+
+## 💬 Additional Notes
+
+Follow repository style guidelines and run tests with `pytest -q`.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/7-Justification.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/7-Justification.md
@@ -1,0 +1,49 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions.md
+
+## 🧠 Context
+
+Verify correctness, robustness, and coverage of the `solarwindpy.fitfunctions` submodule.
+
+## 🎯 Overview of the Task
+
+1. **Safety and regression**: non‑public helpers guard data integrity.
+1. **Numerical correctness**: fitting and parameter extraction must remain accurate.
+1. **API contracts**: string formats (`TeX`), plotting behaviors, and property outputs must be stable.
+1. **Edge cases**: zero‑size data, insufficient observations, bad weights, solver failures—ensures graceful degradation.
+
+## 🔧 Framework & Dependencies
+
+- `pytest`
+- `flake8`
+- `black`
+
+## 📂 Affected Files and Paths
+
+- `solarwindpy/fitfunctions/*`
+- `tests/fitfunctions/*`
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None.
+
+## ✅ Acceptance Criteria
+
+- [ ] Document justification for comprehensive tests and edge-case coverage.
+
+## 🧩 Decomposition Instructions (Optional)
+
+None.
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None.
+
+## 💬 Additional Notes
+
+Aligns with `AGENTS.md`: run with `pytest -q`, enforce no skipped tests, maintain code style with `flake8` and `black`.


### PR DESCRIPTION
## Summary
- split combined fitfunctions test plan into seven standalone templates
- restore plan front matter and remove placeholder tokens

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689059ff050c832ca6a620c38ba5fb9d