### PR TITLE
docs(plans): split plotting test plan

### DIFF
--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/1-base.py.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/1-base.py.md
@@ -1,0 +1,85 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+### 1.1 Class `Base` (abstract)
+
+- Instantiation via subclass to ensure `_init_logger`, `_labels`, `_log`, and `path`
+  setup.
+- `__str__` returns the class name.
+- Properties `data`, `clip`, `log`, `labels`, `path` reflect internal state.
+- `set_log(x, y)` toggles `log.x` and `log.y`; cover defaults and explicit
+  values.
+- `set_labels(auto_update_path=True)` updates `labels` and regenerates `path`.
+  Passing an unexpected kwarg raises `KeyError`.
+
+## 🎯 Overview of the Task
+
+Implement comprehensive tests for `base.py` within the `solarwindpy.plotting` package.
+
+## 🔧 Framework & Dependencies
+
+- pandas
+- matplotlib
+- pytest
+
+## 📂 Affected Files and Paths
+
+- solarwindpy/plotting/base.py
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Instantiate a minimal subclass of `Base` to verify `_init_logger`,
+  `_labels`, `_log` and `path` are initialized
+- [ ] Verify that `__str__` returns the class name
+- [ ] Verify that `.data` property returns the internal `_data`
+- [ ] Verify that `.clip` property returns the internal `_clip`
+- [ ] Verify that `.log` property returns the internal `_log`
+- [ ] Verify that `.labels` property returns the internal `_labels`
+- [ ] Verify that `.path` property returns the internal `_path`
+- [ ] Test `set_log()` with defaults toggles `log.x` and `log.y` appropriately
+- [ ] Test `set_log(x=True, y=False)` correctly updates `log` axes
+- [ ] Test `set_labels()` updates labels and regenerates `path`
+- [ ] Verify that `set_labels(unexpected=…)` raises `KeyError`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+- Ensures correct functionality, edge-case handling, API stability, and protects
+  non-public internals.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/2-agg_plot.py.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/2-agg_plot.py.md
@@ -1,0 +1,84 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+### 2.1 Class `AggPlot(Base)`
+
+- Properties `edges`, `categoricals`, `intervals`, `cut`, `clim`,
+  `agg_axes`, `joint`, `grouped`, `axnorm`.
+- Static method `clip_data(data, clip)` handles series vs. DataFrame, `'l'`, `'u'`,
+  and numeric clipping. Invalid types raise `TypeError`.
+- `set_clim(lower, upper)` sets `_clim`.
+- *Justification*: foundation for all histogram and heatmap classes.
+
+## 🎯 Overview of the Task
+
+Implement comprehensive tests for `agg_plot.py` within the `solarwindpy.plotting` package.
+
+## 🔧 Framework & Dependencies
+
+- pandas
+- matplotlib
+- pytest
+
+## 📂 Affected Files and Paths
+
+- solarwindpy/plotting/agg_plot.py
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Verify `.edges` property constructs correct bin-edge arrays
+- [ ] Verify `.categoricals` property returns categorical bins mapping
+- [ ] Verify `.intervals` property returns correct `IntervalIndex` objects
+- [ ] Verify `.cut` property returns the internal `_cut` DataFrame
+- [ ] Verify `.clim` property returns the internal `_clim` tuple
+- [ ] Verify `.agg_axes` returns the correct aggregation column
+- [ ] Verify `.joint` returns a `Series` with a `MultiIndex`
+- [ ] Verify `.grouped` returns a `GroupBy` on the correct axes
+- [ ] Verify `.axnorm` returns the internal `_axnorm` value
+- [ ] Test `clip_data(pd.Series, 'l')`, `'u'`, numeric → correct clipping
+- [ ] Test `clip_data(pd.DataFrame, …)` with lower/upper modes
+- [ ] Verify `clip_data()` raises `TypeError` on unsupported input
+- [ ] Test `set_clim(2, 10)` sets `_clim` to `(2, 10)`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+- Ensures correct functionality, edge-case handling, API stability, and protects
+  non-public internals.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/3-histograms.py.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/3-histograms.py.md
@@ -1,0 +1,195 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+### 3.1 Module exports
+
+- Test that `AggPlot`, `Hist1D`, and `Hist2D` are re-exported correctly.
+
+### 3.2 `hist1d.py` → Class `Hist1D(AggPlot)`
+
+- `__init__(x, y=None, logx, axnorm, clip_data, nbins, bin_precision)`
+  handles default count vs. y-aggregation and `logx=True` transforms data.
+- `_gb_axes` returns `('x',)`.
+- `set_path(new, add_scale)` accepts `"auto"` vs. custom paths.
+- `set_data(x, y, clip)` ensures correct DataFrame shape and stores clip flag.
+- `set_axnorm(new)` validates keys (`d`, `t`); invalid keys raise
+  `AssertionError`.
+- `construct_cdf(only_plotted)` produces a CDF or raises `ValueError` for
+  invalid data.
+- `_axis_normalizer(agg)` supports None, density, total; invalid values raise
+  `ValueError`.
+- `agg(**kwargs)` requires `fcn='count'` with density normalization; otherwise
+  raises `ValueError`.
+- `set_labels(y=…)` updates labels; providing `z` raises `ValueError`.
+- `make_plot(ax, fcn, transpose_axes, **kwargs)` returns `(ax, (pl, cl, bl))`.
+  Test error bar parameters, transpose axes, and invalid `fcn`.
+
+### 3.3 `hist2d.py` → Class `Hist2D(AggPlot, PlotWithZdata, CbarMaker)`
+
+- `__init__(x, y, z=None, logx, logy, clip_data, nbins, bin_precision)`.
+- `_gb_axes` and `_maybe_convert_to_log_scale(x, y)`.
+- `set_labels(z=…)` and `set_data(x, y, z, clip)` including log transforms.
+- `set_axnorm(new)` accepts `c`, `r`, `t`, `d`; invalid keys raise
+  `AssertionError`.
+- `_axis_normalizer(agg)` handles each normalization branch and iter-norm;
+  invalid values raise `ValueError`.
+- `agg(**kwargs)` wraps `super().agg`, applies normalizer, and reindexes.
+- `_make_cbar(mappable, **kwargs)` provides default ticks for `c`/`r` norms.
+- `_limit_color_norm(norm)` applies percentile clipping.
+- `make_plot(ax, cbar, limit_color_norm, cbar_kwargs, fcn, alpha_fcn, **kwargs)`
+  returns `(ax, Colorbar|QuadMesh)` and masks invalid data.
+
+### 3.4 `scatter.py`
+
+### Class `Scatter(PlotWithZdata, CbarMaker)`
+
+- `__init__(x, y, z=None, clip_data)`.
+- `_format_axis(ax, collection)` updates `sticky_edges` and data limits.
+- `make_plot(ax, cbar, cbar_kwargs, **kwargs)` handles single vs. multiple
+  `z`, colorbar creation, and `clip_data` path.
+
+### 3.5 `spiral.py`
+
+### Numba helpers
+
+- `get_counts_per_bin(bins, x, y)` and `calculate_bin_number_with_numba(mesh, x, y)`
+  operate on small synthetic bins/data to produce correct counts and bin
+  assignments.
+
+### Class `SpiralMesh`
+
+- Properties: `bin_id`, `cat`, `data`, `initial_edges`, `mesh`, `min_per_bin`,
+  `cell_filter_thresholds`.
+- `cell_filter` combines `density` and `size` thresholds.
+- `set_cell_filter_thresholds(density, size)` validates kwargs; invalid keys
+  raise `KeyError`.
+- `set_initial_edges`, `set_min_per_bin`, and `set_data` update internal state.
+- `initialize_bins()` builds mesh of expected shape.
+
+## 🎯 Overview of the Task
+
+Implement comprehensive tests for `histograms.py` within the `solarwindpy.plotting` package.
+
+## 🔧 Framework & Dependencies
+
+- pandas
+- matplotlib
+- pytest
+
+## 📂 Affected Files and Paths
+
+- solarwindpy/plotting/histograms.py
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Verify `__all__` includes `AggPlot`, `Hist1D`, `Hist2D`
+- [ ] Test `__init__(x_series)` produces a count histogram
+- [ ] Test `__init__(x, y_series)` aggregates `y` values
+- [ ] Test `__init__(…, logx=True)` applies log₁₀ transform to `x`
+- [ ] Verify `_gb_axes` property returns `('x',)`
+- [ ] Test `set_path('auto')` builds path from labels
+- [ ] Test `set_path('custom', add_scale=False)` sets `_path` to `Path('custom')`
+- [ ] Test `set_data(x, y, clip=True)` stores DataFrame with columns `x`,`y`
+  & `clip`
+- [ ] Verify `.clip` attribute equals `clip` flag
+- [ ] Test `set_axnorm('d')` sets density normalization and updates label
+- [ ] Test `set_axnorm('t')` sets total normalization
+- [ ] Verify `set_axnorm('x')` raises `AssertionError`
+- [ ] Test `construct_cdf(only_plotted=True)` yields correct CDF DataFrame
+- [ ] Verify `construct_cdf()` on non-histogram data raises `ValueError`
+- [ ] Test `_axis_normalizer(None)` returns input unchanged
+- [ ] Test `_axis_normalizer('d')` computes PDF correctly
+- [ ] Test `_axis_normalizer('t')` normalizes by max
+- [ ] Verify `_axis_normalizer('bad')` raises `ValueError`
+- [ ] Test `agg(fcn='count')` with `axnorm='d'` works
+- [ ] Verify `agg(fcn='sum', axnorm='d')` raises `ValueError`
+- [ ] Verify `agg()` output reindexed correctly
+- [ ] Test `set_labels(y='new')` updates y-label
+- [ ] Verify `set_labels(z='z')` raises `ValueError`
+- [ ] Test `make_plot(ax)` returns `(ax,(pl,cl,bl))` with
+  `drawstyle='steps-mid'`
+- [ ] Test `make_plot(ax, transpose_axes=True)` swaps axes
+- [ ] Verify `make_plot(fcn='bad')` raises `ValueError`
+- [ ] Test `make_plot(ax, errorbar=True)` renders error bars correctly
+- [ ] Test `__init__(x, y)` produces 2D count heatmap
+- [ ] Test `__init__(x, y, z)` aggregates mean of `z`
+- [ ] Verify `_gb_axes` returns `('x','y')`
+- [ ] Test `_maybe_convert_to_log_scale` with `logx/logy=True`
+- [ ] Test `set_data(x, y, z, clip)` applies log transform
+- [ ] Test `set_labels(z='z')` updates z-label
+- [ ] Verify `set_axnorm('c')`, `'r'`, `'t'`, `'d'` work; invalid →
+  `AssertionError`
+- [ ] Test `_axis_normalizer()` for each norm branch
+- [ ] Verify `_axis_normalizer(('c','sum'))` applies custom function
+- [ ] Verify `_axis_normalizer('bad')` raises `ValueError`
+- [ ] Test `_make_cbar()` yields correct `ticks` for `c`/`r`
+- [ ] Test `_limit_color_norm()` sets `vmin`,`vmax`,`clip` properly
+- [ ] Test `make_plot(ax, cbar=False)` returns `QuadMesh`
+- [ ] Test `make_plot(limit_color_norm=True, cbar=True)` applies limits
+- [ ] Test `make_plot` masks invalid data via `alpha_fcn`
+- [ ] Test `make_plot` forwards `cbar_kwargs` to colorbar
+- [ ] Test `__init__(x,y)` draws scatter without colorbar
+- [ ] Test `__init__(x,y,z)` draws scatter with colorbar
+- [ ] Verify `_format_axis()` updates `sticky_edges` & data limits
+- [ ] Test `make_plot(ax, cbar=False)` returns `(ax,None)`
+- [ ] Test `make_plot(ax, cbar=True)` returns `(ax,Colorbar)`
+- [ ] Test `clip_data` path invoked when `clip=True`
+- [ ] Test `get_counts_per_bin()` on synthetic bins → correct counts
+- [ ] Test `calculate_bin_number_with_numba()` assigns correct bin IDs
+- [ ] Verify `.bin_id` property returns bin IDs
+- [ ] Verify `.cat` property returns category labels
+- [ ] Verify `.data` property returns stored input data
+- [ ] Verify `.initial_edges` property returns initial bin edges
+- [ ] Verify `.mesh` property returns computed mesh
+- [ ] Verify `.min_per_bin` property returns minimum per bin
+- [ ] Verify `.cell_filter_thresholds` property returns filter thresholds
+- [ ] Test `set_cell_filter_thresholds(density=0.1,size=0.9)` updates thresholds
+- [ ] Verify `set_cell_filter_thresholds(bad=…)` raises `KeyError`
+- [ ] Test `.cell_filter` logic for density & size filters
+- [ ] Test `set_initial_edges()` updates initial bin edges
+- [ ] Test `set_min_per_bin()` updates minimum per bin
+- [ ] Test `set_data()` stores input data
+- [ ] Test `initialize_bins()` constructs mesh of expected shape
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+- Ensures correct functionality, edge-case handling, API stability, and protects
+  non-public internals.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/4-orbits.py.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/4-orbits.py.md
@@ -1,0 +1,102 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+### Class `OrbitPlot(ABC)`
+
+- `__init__(orbit, *args)` validates `orbit` type; invalid types raise
+  `TypeError`.
+- Properties: `_disable_both`, `orbit`, `_orbit_key`, `grouped`.
+- `set_path(*args, orbit=…)` appends orbit path.
+- `set_orbit(new)` sorts orbits and validates type.
+- `make_cut()` adds “Inbound”/“Outbound” (and “Both”) categories.
+
+### Class `OrbitHist1D(OrbitPlot, Hist1D)`
+
+- `_format_axis(ax)` adds legend.
+- `agg(**kwargs)` merges “Both” leg; disabled via `_disable_both`.
+- `make_plot(ax, fcn, **kwargs)` calls `tools.subplots` and plots each leg.
+
+### Class `OrbitHist2D(OrbitPlot, Hist2D)`
+
+- `_format_in_out_axes(inbound, outbound)`, `_prune_lower_yaxis_ticks`, and
+  `_format_in_out_both_axes` manage axis formatting.
+- `agg(**kwargs)` wraps and normalizes per-orbit.
+- `project_1d(axis, project_counts, **kwargs)` returns an `OrbitHist1D`
+  instance.
+
+## 🎯 Overview of the Task
+
+Implement comprehensive tests for `orbits.py` within the `solarwindpy.plotting` package.
+
+## 🔧 Framework & Dependencies
+
+- pandas
+- matplotlib
+- pytest
+
+## 📂 Affected Files and Paths
+
+- solarwindpy/plotting/orbits.py
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Verify invalid `orbit` type in `__init__` raises `TypeError`
+- [ ] Verify `_disable_both` property is `True` by default
+- [ ] Verify `.orbit` property returns the `IntervalIndex`
+- [ ] Verify `_orbit_key` returns `"Orbit"`
+- [ ] Verify `.grouped` groups by `_gb_axes` + `_orbit_key`
+- [ ] Test `set_path(…, orbit=idx)` appends `orbit.path`
+- [ ] Test `set_orbit(idx)` sorts and validates type
+- [ ] Test `make_cut()` adds “Inbound”/“Outbound” (and “Both”) categories
+- [ ] Verify `_format_axis(ax)` adds a legend
+- [ ] Test `agg()` merges “Both” leg when `_disable_both=False`
+- [ ] Test `make_plot(ax)` plots each orbit leg via `tools.subplots()`
+- [ ] Test `_format_in_out_axes()` swaps x-limits and colors spines
+- [ ] Test `_prune_lower_yaxis_ticks()` prunes ticks correctly
+- [ ] Test `_format_in_out_both_axes()` aligns y-limits across
+  inbound/outbound/both
+- [ ] Test `agg()` normalizes per-orbit legs
+- [ ] Test `project_1d('x')` returns a valid `OrbitHist1D`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+- Ensures correct functionality, edge-case handling, API stability, and protects
+  non-public internals.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/5-tools.py.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/5-tools.py.md
@@ -1,0 +1,80 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+- `subplots(nrows, ncols, scale_width, scale_height, **kwargs)` scales figure
+  size with grid shape.
+- `save(fig, spath, add_info, log, pdf, png, **kwargs)` writes `.pdf` and `.png`
+  files, adds timestamp text, and supports optional logging.
+- `joint_legend(*axes, idx_for_legend, **kwargs)` merges legend entries without
+  duplicates and sorts them.
+- `multipanel_figure_shared_cbar(...)` (if present) creates grid with shared
+  colorbar.
+
+## 🎯 Overview of the Task
+
+Implement comprehensive tests for `tools.py` within the `solarwindpy.plotting` package.
+
+## 🔧 Framework & Dependencies
+
+- pandas
+- matplotlib
+- pytest
+
+## 📂 Affected Files and Paths
+
+- solarwindpy/plotting/tools.py
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Test `subplots(2,2,scale_width=1.5,scale_height=0.5)` returns 2×2 axes with
+  correct figsize
+- [ ] Test `save(fig, path, pdf=True,png=True)` writes both `.pdf` and `.png`
+  files
+- [ ] Test PNG version includes timestamp text
+- [ ] Test `save(..., log=False)` skips logging calls
+- [ ] Test `joint_legend(ax1,ax2)` merges legend entries, no duplicates, sorted
+- [ ] (If present) Test `multipanel_figure_shared_cbar(...)` arranges shared
+  colorbar correctly
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+- Ensures correct functionality, edge-case handling, API stability, and protects
+  non-public internals.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/6-select_data_from_figure.py.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/6-select_data_from_figure.py.md
@@ -1,0 +1,91 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+### Class `SelectFromPlot2D`
+
+- `__init__(plotter, ax, has_colorbar, xdate, ydate, text_kwargs)`.
+- Properties: `ax`, `corners`, `date_axes`, `is_multipanel`, `selector`, `text`,
+  and more.
+- `_init_corners`, `_add_corners`, `_finalize_text`, `_update_text` manage
+  corner selection and text updates.
+- `disconnect(other, scatter_kwargs, **kwargs)` calls `sample_data`,
+  `scatter_sample`, and `plot_failed_samples`.
+- `onselect(press, release)` adds patch, updates corners and text.
+- `set_ax(ax, has_colorbar)`, `start_text`, `start_selector`, `sample_data(n, random_state)`; `sample_data(frac=…)` raises `NotImplementedError`.
+
+## 🎯 Overview of the Task
+
+Implement comprehensive tests for `select_data_from_figure.py` within the `solarwindpy.plotting` package.
+
+## 🔧 Framework & Dependencies
+
+- pandas
+- matplotlib
+- pytest
+
+## 📂 Affected Files and Paths
+
+- solarwindpy/plotting/select_data_from_figure.py
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Test `__init__(plotter,ax)` initializes selector and text objects
+- [ ] Verify `.ax`, `.corners`, `.date_axes`, `.is_multipanel` props
+- [ ] Verify `.selector` property exposes selector object
+- [ ] Verify `.text` property exposes text annotation
+- [ ] Test `_init_corners()` initializes corner coordinates
+- [ ] Test `_add_corners()` appends new corner tuples
+- [ ] Test `_finalize_text()` formats final selection text
+- [ ] Test `_update_text()` formats bounding-box extents
+- [ ] Test `onselect(press,release)` adds rectangle patch and updates
+  corners/text
+- [ ] Test `disconnect()` calls `sample_data()`, `scatter_sample()`,
+  `plot_failed_samples()`, disconnects events
+- [ ] Test `set_ax(ax, has_colorbar)` updates axis and colorbar state
+- [ ] Test `start_text()` initializes the annotation text object
+- [ ] Test `start_selector()` starts selection widget
+- [ ] Test `sample_data(n=3,random_state=…)` returns correct sampled indices
+- [ ] Verify `sample_data(frac=0.1)` raises `NotImplementedError`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+- Ensures correct functionality, edge-case handling, API stability, and protects
+  non-public internals.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/7-labels-base.py.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/7-labels-base.py.md
@@ -1,0 +1,69 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+- Namedtuples: `LogAxes`, `AxesLabels`, `RangeLimits` with defaults and custom
+  values.
+- Class `Base`: shared logic with `plotting/base`.
+
+## 🎯 Overview of the Task
+
+Implement comprehensive tests for `labels/base.py` within the `solarwindpy.plotting` package.
+
+## 🔧 Framework & Dependencies
+
+- pandas
+- matplotlib
+- pytest
+
+## 📂 Affected Files and Paths
+
+- solarwindpy/plotting/labels/base.py
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Verify `LogAxes`, `AxesLabels`, `RangeLimits` namedtuples have correct
+  defaults
+- [ ] (Shared with plotting/base) Repeat `Base` tests if context differs
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+- Ensures correct functionality, edge-case handling, API stability, and protects
+  non-public internals.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/8-labels-special.py.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/8-labels-special.py.md
@@ -1,0 +1,90 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+### Abstract `ArbitraryLabel(Base)`
+
+- Cannot instantiate; subclass must implement `__str__`.
+
+### `ManualLabel(tex, unit, path=None)`
+
+- `set_tex` and `set_unit` strip `$` and map units via `base._inU`.
+- `__str__` and `path` manage default vs. custom paths.
+
+### Prebuilt labels
+
+- `Vsw`, `CarringtonRotation(short_label)`, `Count(norm)`, `Power`,
+  `Probability(other_label, comparison)` verify `tex`, `units`, `path`, and
+  error on invalid input.
+
+## 🎯 Overview of the Task
+
+Implement comprehensive tests for `labels/special.py` within the `solarwindpy.plotting` package.
+
+## 🔧 Framework & Dependencies
+
+- pandas
+- matplotlib
+- pytest
+
+## 📂 Affected Files and Paths
+
+- solarwindpy/plotting/labels/special.py
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Verify instantiating `ArbitraryLabel` directly raises `TypeError`
+- [ ] Test `set_tex('$X$')` strips dollar signs
+- [ ] Test `set_unit('km')` maps via `base._inU`
+- [ ] Verify `__str__` formats `tex` and `unit` correctly
+- [ ] Verify `.path` property returns default (from `tex`) and custom path
+- [ ] Verify `Vsw.tex`, `Vsw.units`, `Vsw.path`
+- [ ] Test `CarringtonRotation(short_label=False)` toggles `tex` output
+- [ ] Test `Count(norm='d')` builds `tex` and `path` for density norm
+- [ ] Test `Count(norm=None)` builds default count label
+- [ ] Verify `Power` and `Probability(other_label,comparison)` produce correct
+  `tex`,`units`,`path`
+- [ ] Verify invalid `other_label` or `comparison` in `Probability` raises
+  `AssertionError`
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+- Ensures correct functionality, edge-case handling, API stability, and protects
+  non-public internals.

--- a/solarwindpy/plans/combined_test_plan_with_checklist_plotting/9-Fixtures-and-Utilities.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_plotting/9-Fixtures-and-Utilities.md
@@ -1,0 +1,77 @@
+---
+name: SweepAI Task Template
+about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+labels: [sweep]
+---
+
+> Extracted from solarwindpy/plans/combined_test_plan_with_checklist_plotting.md
+
+## 🧠 Context
+
+The `solarwindpy.plotting` subpackage offers high-level plotting utilities built on pandas
+and Matplotlib. This unified plan combines the narrative test rationale and the
+actionable checklist for validating every class, method, property (including non-public
+interfaces), and helper function across:
+
+- `base.py`
+- `agg_plot.py`
+- `histograms.py` (`hist1d.py`, `hist2d.py`)
+- `scatter.py`
+- `spiral.py`
+- `orbits.py`
+- `tools.py`
+- `select_data_from_figure.py`
+- `labels/base.py`
+- `labels/special.py`
+
+Tests are grouped by module. Each module section includes context from the original
+narrative plan followed by a deduplicated checklist of actionable items.
+
+- `pytest` fixtures: dummy `Series`, `DataFrame`, `IntervalIndex`, `Axes` from
+  `plt.subplots()`.
+- `tmp_path` for file I/O.
+- Parameterized tests across modes and combinations.
+
+### Justification
+
+- Ensures correct functionality, edge-case handling, API stability, and protects
+  non-public internals.
+
+## 🎯 Overview of the Task
+
+Implement comprehensive tests for Fixtures & Utilities within the `solarwindpy.plotting` package.
+
+## 🔧 Framework & Dependencies
+
+- pandas
+- matplotlib
+- pytest
+
+## 📂 Affected Files and Paths
+
+- solarwindpy/plotting/Fixtures & Utilities
+
+## 📊 Figures, Diagrams, or Artifacts (Optional)
+
+None
+
+## ✅ Acceptance Criteria
+
+- [ ] Create dummy `Series` fixture for tests
+- [ ] Create dummy `DataFrame` fixture for tests
+- [ ] Create dummy `IntervalIndex` fixture for tests
+- [ ] Use `tmp_path` fixture for file I/O tests
+- [ ] Parameterize tests across modes and combinations
+
+## 🧩 Decomposition Instructions (Optional)
+
+None
+
+## 🤖 Sweep Agent Instructions (Optional)
+
+None
+
+## 💬 Additional Notes
+
+- Ensures correct functionality, edge-case handling, API stability, and protects
+  non-public internals.


### PR DESCRIPTION
## Summary
- split plotting combined test plan into module-specific docs
- use standard template with context and acceptance criteria

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689059e6ed60832c82a6b5a3fd7662d8