### PR TITLE
docs(plans): fix argnames criterion formatting

### DIFF
--- a/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/2-core.py-FitFunction.md
+++ b/solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/2-core.py-FitFunction.md
@@ -77,7 +77,7 @@ None.
 - [ ] Test `_build_outside_mask` with `outside=None` (all `True`).
 - [ ] Test `_build_outside_mask` with valid tuple (only outside points `True`).
 - [ ] Test `set_fit_obs` for combined masks (`x`, `y`, `wmin`, `wmax`, `logy`).
-- [ ] Test `_set_argnames` on subclass with known signature (`argnames` matches function arguments\`).
+- [ ] Test `_set_argnames` on subclass with known signature (`argnames` matches function arguments`).
 - [ ] Test `_run_least_squares` with monkey-patched optimizer (dummy `OptimizeResult`).
 - [ ] Test `_run_least_squares` for default kwargs (`loss`, `method`, etc.).
 - [ ] Test `_run_least_squares` for invalid `args` kwarg (`ValueError`).


### PR DESCRIPTION
## Summary
- remove stray backslash in `_set_argnames` acceptance criterion to render inline code properly

## Testing
- `markdownlint solarwindpy/plans/combined_test_plan_with_checklist_fitfunctions/2-core.py-FitFunction.md` *(fails: first-line-heading, line-length, inline HTML)*
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689065a0c6c4832caf53d60f75bc271e