### PR TITLE
docs: clarify plan section headers

### DIFF
--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/1-Overview-and-Goals.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/1-Overview-and-Goals.md
@@ -1,6 +1,6 @@
 ---
-name: SweepAI Task Template
-about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+name: Combined Plan and Checklist Documentation – Overview and Goals
+about: Summarizes the overarching aims and scope for SolarWindPy's documentation.
 labels: [sweep]
 ---
 
@@ -8,7 +8,8 @@ labels: [sweep]
 
 ## 🧠 Context
 
-This section outlines the overarching aims and scope for SolarWindPy's documentation effort.
+This section outlines the overarching aims and scope for SolarWindPy's
+documentation effort.
 
 ## 🎯 Overview of the Task
 

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/2-Toolchain-and-Hosting.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/2-Toolchain-and-Hosting.md
@@ -1,6 +1,6 @@
 ---
-name: SweepAI Task Template
-about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+name: Combined Plan and Checklist Documentation – Toolchain and Hosting
+about: Defines the tools and hosting strategy for building and publishing documentation.
 labels: [sweep]
 ---
 
@@ -8,17 +8,19 @@ labels: [sweep]
 
 ## 🧠 Context
 
-Defines the tools and hosting strategy for building and publishing documentation.
+Defines the tools and hosting strategy for building and publishing
+documentation.
 
 ## 🎯 Overview of the Task
 
 - Documentation generator: Sphinx
-  - Extensions: `sphinx.ext.autodoc`, `sphinx.ext.napoleon`, `sphinx.ext.mathjax`,
-    `sphinx.ext.viewcode`, `sphinx.ext.githubpages`.
+  - Extensions: `sphinx.ext.autodoc`, `sphinx.ext.napoleon`,
+    `sphinx.ext.mathjax`, `sphinx.ext.viewcode`, `sphinx.ext.githubpages`.
   - Theme: `sphinx_rtd_theme`.
 - Environment:
   - `docs/requirements.txt` lists Sphinx and related extensions.
-  - `docs/Makefile` and `docs/make.bat` provide `html`, `clean`, and `spellcheck` targets.
+  - `docs/Makefile` and `docs/make.bat` provide `html`, `clean`, and
+    `spellcheck` targets.
 - Hosting:
   - Read the Docs for versioned builds.
   - GitHub Pages via a `gh-pages` branch.
@@ -45,12 +47,14 @@ N/A
 
 ## ✅ Acceptance Criteria
 
-- [ ] Evaluate existing docs infrastructure under `docs/` (e.g., Sphinx config, extensions).
+- [ ] Evaluate existing docs infrastructure under `docs/` (e.g., Sphinx config,
+  extensions).
 - [ ] Decide to continue with Sphinx versus evaluate alternatives.
-- [ ] Review benefits of plugins such as `sphinx.ext.viewcode` and `sphinx.ext.githubpages`.
+- [ ] Review benefits of plugins such as `sphinx.ext.viewcode` and
+  `sphinx.ext.githubpages`.
 - [ ] Create `docs/requirements.txt` listing Sphinx and related extensions.
-- [ ] Update `docs/Makefile` and `docs/make.bat` to include `html`, `clean`, and `spellcheck`
-  targets.
+- [ ] Update `docs/Makefile` and `docs/make.bat` to include `html`, `clean`, and
+  `spellcheck` targets.
 
 ## 🧩 Decomposition Instructions (Optional)
 

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/3-Repository-Structure.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/3-Repository-Structure.md
@@ -1,6 +1,6 @@
 ---
-name: SweepAI Task Template
-about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+name: Combined Plan and Checklist Documentation – Repository Structure
+about: Provides the repository layout relevant to documentation.
 labels: [sweep]
 ---
 
@@ -27,7 +27,8 @@ SolarWindPy/
 
 ## 🎯 Overview of the Task
 
-Summarize and maintain the structure shown above to support documentation development.
+Summarize and maintain the structure shown above to support documentation
+development.
 
 ## 🔧 Framework & Dependencies
 

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/4-Configuration-and-Standards.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/4-Configuration-and-Standards.md
@@ -1,6 +1,6 @@
 ---
-name: SweepAI Task Template
-about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+name: Combined Plan and Checklist Documentation – Configuration and Standards
+about: Sets configuration choices and documentation standards for the project.
 labels: [sweep]
 ---
 
@@ -19,8 +19,8 @@ Sets configuration choices and documentation standards for the project.
   - Retrieve `version` from package metadata instead of hardcoding it.
 - Standardize docstrings to NumPy style across the codebase.
   - Include `Parameters`, `Returns`, `Raises`, and `Examples` sections.
-  - Audit modules (`core/`, `fitfunctions/`, `instabilities/`, `plotting/`, etc.) for missing or
-    incomplete docstrings.
+  - Audit modules (`core/`, `fitfunctions/`, `instabilities/`, `plotting/`,
+    etc.) for missing or incomplete docstrings.
 
 ## 🔧 Framework & Dependencies
 
@@ -43,15 +43,17 @@ N/A
 
 ## ✅ Acceptance Criteria
 
-- [ ] Verify that `docs/source/conf.py` loads `autodoc`, `todo`, `mathjax`, `viewcode`, and
-  `githubpages`.
+- [ ] Verify that `docs/source/conf.py` loads `autodoc`, `todo`, `mathjax`,
+  `viewcode`, and `githubpages`.
 - [ ] Retrieve package `version` dynamically in `docs/source/conf.py`.
 - [ ] Confirm that the theme `sphinx_rtd_theme` is set appropriately.
 - [ ] Check that the source file suffix is `.rst` and master doc is `index.rst`.
-- [ ] Add `sphinx.ext.napoleon` extension to parse NumPy/Google-style docstrings.
+- [ ] Add `sphinx.ext.napoleon` extension to parse NumPy/Google-style
+  docstrings.
 - [ ] Audit all public modules and classes for missing docstrings.
 - [ ] Standardize all existing docstrings to NumPy style.
-- [ ] Add missing sections such as `Examples`, `Notes`, and `Attributes` where relevant.
+- [ ] Add missing sections such as `Examples`, `Notes`, and `Attributes` where
+  relevant.
 - [ ] Remove or address any `TODO` placeholders related to documentation.
 - [ ] Ensure `flake8-docstrings` rules D205/D406 are enabled in `setup.cfg`.
 

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/5-Documentation-Content.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/5-Documentation-Content.md
@@ -1,6 +1,6 @@
 ---
-name: SweepAI Task Template
-about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+name: Combined Plan and Checklist Documentation – Documentation Content
+about: Outlines the content to include in the documentation set.
 labels: [sweep]
 ---
 
@@ -18,8 +18,8 @@ Outlines the content to include in the documentation set.
   - `usage.rst`
   - `tutorial.rst`
   - `api_reference.rst`
-- Add tutorial pages such as `docs/source/tutorial/quickstart.rst` for installation and basic
-  workflow.
+- Add tutorial pages such as `docs/source/tutorial/quickstart.rst` for
+  installation and basic workflow.
 - Generate API reference pages with `sphinx-apidoc` and `autosummary`.
 
 ## 🔧 Framework & Dependencies
@@ -40,12 +40,13 @@ N/A
 
 ## ✅ Acceptance Criteria
 
-- [ ] Update `docs/source/index.rst` to include `installation.rst`, `usage.rst`, `tutorial.rst`, and
-  `api_reference.rst`.
+- [ ] Update `docs/source/index.rst` to include `installation.rst`, `usage.rst`,
+  `tutorial.rst`, and `api_reference.rst`.
 - [ ] Create `installation.rst` with installation instructions (pip, conda).
 - [ ] Create `usage.rst` with basic usage examples.
 - [ ] Create `tutorial.rst` with a step-by-step tutorial.
-- [ ] Generate API reference via `sphinx-apidoc` and include in `api_reference.rst`.
+- [ ] Generate API reference via `sphinx-apidoc` and include in
+  `api_reference.rst`.
 - [ ] Run `sphinx-apidoc` to regenerate module stub files.
 
 ## 🧩 Decomposition Instructions (Optional)

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/6-CI-CD-and-Validation.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/6-CI-CD-and-Validation.md
@@ -1,6 +1,6 @@
 ---
-name: SweepAI Task Template
-about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+name: Combined Plan and Checklist Documentation – CI/CD and Validation
+about: Details the continuous integration and validation steps for documentation.
 labels: [sweep]
 ---
 
@@ -12,11 +12,12 @@ Details the continuous integration and validation steps for documentation.
 
 ## 🎯 Overview of the Task
 
-- Add CI workflow `.github/workflows/doc-build.yml` to build documentation and fail on warnings.
+- Add CI workflow `.github/workflows/doc-build.yml` to build documentation and
+  fail on warnings.
 - Use GitHub Actions to deploy to `gh-pages`.
 - Configure Read the Docs with `.readthedocs.yaml`.
-- Validate locally by running `sphinx-apidoc` and `make html` without errors or warnings and testing
-  links and snippets.
+- Validate locally by running `sphinx-apidoc` and `make html` without errors or
+  warnings and testing links and snippets.
 
 ## 🔧 Framework & Dependencies
 
@@ -36,12 +37,13 @@ N/A
 
 ## ✅ Acceptance Criteria
 
-- [ ] Add CI workflow `.github/workflows/doc-build.yml` to install docs requirements and run
-  `make html`.
+- [ ] Add CI workflow `.github/workflows/doc-build.yml` to install docs
+  requirements and run `make html`.
 - [ ] Execute `make html` in `docs/` and confirm no errors or warnings.
 - [ ] Test links, code snippets, and formatting in the generated site.
 - [ ] Configure Read the Docs with `.readthedocs.yaml`.
-- [ ] Create `.github/workflows/deploy-docs.yml` to build and push to `gh-pages`.
+- [ ] Create `.github/workflows/deploy-docs.yml` to build and push to
+  `gh-pages`.
 
 ## 🧩 Decomposition Instructions (Optional)
 

--- a/solarwindpy/plans/combined_plan_with_checklist_documentation/7-Maintenance.md
+++ b/solarwindpy/plans/combined_plan_with_checklist_documentation/7-Maintenance.md
@@ -1,6 +1,6 @@
 ---
-name: SweepAI Task Template
-about: Use this template to request a code update, refactor, or documentation change via SweepAI.
+name: Combined Plan and Checklist Documentation – Maintenance
+about: Covers long-term maintenance practices for documentation.
 labels: [sweep]
 ---
 
@@ -37,7 +37,8 @@ N/A
 
 - [ ] Add a documentation badge to `README.rst`.
 - [ ] Document docstring conventions and update workflow in `CONTRIBUTING.md`.
-- [ ] Set up linting for documentation (e.g., `flake8-docstrings`, `rst-lint`, `doc8`) in CI.
+- [ ] Set up linting for documentation (e.g., `flake8-docstrings`, `rst-lint`,
+  `doc8`) in CI.
 - [ ] Schedule periodic review of documentation coverage.
 - [ ] Create `.github/PULL_REQUEST_TEMPLATE.md` to prompt docstring updates.
 


### PR DESCRIPTION
## Summary
- clarify metadata for documentation plan sections with descriptive names and purposes

## Testing
- `mdformat --check solarwindpy/plans/combined_plan_with_checklist_documentation/1-Overview-and-Goals.md solarwindpy/plans/combined_plan_with_checklist_documentation/2-Toolchain-and-Hosting.md solarwindpy/plans/combined_plan_with_checklist_documentation/3-Repository-Structure.md solarwindpy/plans/combined_plan_with_checklist_documentation/4-Configuration-and-Standards.md solarwindpy/plans/combined_plan_with_checklist_documentation/5-Documentation-Content.md solarwindpy/plans/combined_plan_with_checklist_documentation/6-CI-CD-and-Validation.md solarwindpy/plans/combined_plan_with_checklist_documentation/7-Maintenance.md`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890db1b0cf8832caa1d006d05d81e19