### PR TITLE
docs: add requirements and build targets

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,11 +9,20 @@ BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+        @$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help Makefile html clean spellcheck
+
+html:
+        @$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+        @$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+spellcheck:
+        @$(SPHINXBUILD) -b spelling "$(SOURCEDIR)" "$(BUILDDIR)/spelling" $(SPHINXOPTS) $(O)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+        @$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -11,6 +11,9 @@ set SOURCEDIR=source
 set BUILDDIR=build
 
 if "%1" == "" goto help
+if "%1" == "html" goto html
+if "%1" == "clean" goto clean
+if "%1" == "spellcheck" goto spellcheck
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
@@ -25,6 +28,21 @@ if errorlevel 9009 (
 	exit /b 1
 )
 
+goto make
+
+:html
+%SPHINXBUILD% -M html %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:clean
+%SPHINXBUILD% -M clean %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:spellcheck
+%SPHINXBUILD% -b spelling %SOURCEDIR% %BUILDDIR%\spelling %SPHINXOPTS%
+goto end
+
+:make
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
 goto end
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+Sphinx>=1.8
+sphinx_rtd_theme
+sphinxcontrib-spelling
+pyenchant

--- a/solarwindpy/plans/issues_from_plans.py
+++ b/solarwindpy/plans/issues_from_plans.py
@@ -221,6 +221,7 @@ def infer_issue_title(path: Path, name: str) -> str:
 
     return f"{dir_title} – {title_part}".strip()
 
+
 def format_summary_table(rows: List[Tuple[str, str]]) -> str:
     """Build a tabulated summary of issue creation outcomes.
 


### PR DESCRIPTION
## Summary
- list Sphinx and extensions in `docs/requirements.txt`
- add `html`, `clean`, and `spellcheck` targets for docs builds
- fix missing blank line to satisfy flake8

## Testing
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_689194a2db4c832cbea9b07e6a2f95b1