### PR TITLE
feat(docs): add Sphinx requirements and build targets

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,5 +1,4 @@
 # Minimal makefile for Sphinx documentation
-#
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
@@ -7,11 +6,20 @@ SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 
+.PHONY: help html clean spellcheck Makefile
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+html:
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+clean:
+	@rm -rf "$(BUILDDIR)"
+
+spellcheck:
+	@$(SPHINXBUILD) -b spelling "$(SOURCEDIR)" "$(BUILDDIR)/spelling" $(SPHINXOPTS) $(O)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -5,7 +5,7 @@ pushd %~dp0
 REM Command file for Sphinx documentation
 
 if "%SPHINXBUILD%" == "" (
-	set SPHINXBUILD=sphinx-build
+        set SPHINXBUILD=sphinx-build
 )
 set SOURCEDIR=source
 set BUILDDIR=build
@@ -14,15 +14,30 @@ if "%1" == "" goto help
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
-	echo.
-	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
-	echo.installed, then set the SPHINXBUILD environment variable to point
-	echo.to the full path of the 'sphinx-build' executable. Alternatively you
-	echo.may add the Sphinx directory to PATH.
-	echo.
-	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
-	exit /b 1
+        echo.
+        echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+        echo.installed, then set the SPHINXBUILD environment variable to point
+        echo.to the full path of the 'sphinx-build' executable. Alternatively you
+        echo.may add the Sphinx directory to PATH.
+        echo.
+        echo.If you don't have Sphinx installed, grab it from
+        echo.http://sphinx-doc.org/
+        exit /b 1
+)
+
+if "%1" == "clean" (
+        rmdir /S /Q %BUILDDIR%
+        goto end
+)
+
+if "%1" == "html" (
+        %SPHINXBUILD% -M html %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+        goto end
+)
+
+if "%1" == "spellcheck" (
+        %SPHINXBUILD% -b spelling %SOURCEDIR% %BUILDDIR%\spelling %SPHINXOPTS%
+        goto end
 )
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx_rtd_theme
+sphinxcontrib-spelling

--- a/solarwindpy/plans/issues_from_plans.py
+++ b/solarwindpy/plans/issues_from_plans.py
@@ -221,6 +221,7 @@ def infer_issue_title(path: Path, name: str) -> str:
 
     return f"{dir_title} – {title_part}".strip()
 
+
 def format_summary_table(rows: List[Tuple[str, str]]) -> str:
     """Build a tabulated summary of issue creation outcomes.
 


### PR DESCRIPTION
## Summary
- add docs requirements for Sphinx, RTD theme and spellcheck
- add explicit html, clean and spellcheck targets for POSIX and Windows builds
- fix flake8 violation in issue plan utility

## Testing
- `black docs/source/conf.py`
- `flake8`
- `pytest -q`
- `make -C docs html`
- `make -C docs spellcheck`
- `make -C docs clean`


------
https://chatgpt.com/codex/tasks/task_e_689198ca09d4832c89ed5c81495ddf54