### PR TITLE
docs: add quickstart tutorial

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,6 +7,7 @@ SolarWindPy Docs
    :caption: Contents:
       
    modules
+   tutorial/quickstart
    solarwindpy.solar_activity.tests
 
 .. include:: ../../LICENSE.rst

--- a/docs/source/tutorial/quickstart.rst
+++ b/docs/source/tutorial/quickstart.rst
@@ -1,0 +1,20 @@
+Quickstart
+==========
+
+Get up and running with SolarWindPy.
+
+Installation
+------------
+
+.. code-block:: bash
+
+   pip install solarwindpy
+
+Basic Usage
+-----------
+
+.. code-block:: python
+
+   import solarwindpy as sw
+   sw.__version__
+


### PR DESCRIPTION
## Summary
- add quickstart tutorial under docs/source/tutorial
- include tutorial in main documentation index

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68919cc99040832c96b9e334c35d11df