### PR TITLE
docs: configure Sphinx and add NumPy-style docstrings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../.."))
+import solarwindpy  # noqa: E402
 
 
 # -- Project information -----------------------------------------------------
@@ -24,10 +25,10 @@ project = "SolarWindPy"
 copyright = "2019, B. L. Alterman"
 author = "B. L. Alterman"
 
-# The short X.Y version
-version = ""
+# Dynamically fetch the package version
+version = solarwindpy.__version__
 # The full version, including alpha/beta/rc tags
-release = "0.0.1-alpha"
+release = version
 
 
 # -- General configuration ---------------------------------------------------
@@ -41,11 +42,14 @@ needs_sphinx = "1.8"
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
 ]
+
+autosummary_generate = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,8 +9,8 @@ tests_require =
 
 
 [flake8]
-add = D402, D413
-ignore = E501, W503, D202, D205, D302, D400
+add = D402, D413, D205, D406
+ignore = E501, W503, D202, D302, D400
 max-line-length = 88
 max-complexity = 18
 exclude =

--- a/solarwindpy/core/alfvenic_turbulence.py
+++ b/solarwindpy/core/alfvenic_turbulence.py
@@ -53,18 +53,20 @@ class AlfvenicTurbulence(base.Core):
     """
 
     def __init__(self, velocity, bfield, rho, species, **kwargs):
-        r"""Initialize an :py:class:`AlfvenicTurbulence` object.
+        """Initialize the turbulence diagnostics.
 
         Parameters
         ----------
-        velocity: pd.DataFrame
-            Vector velocity measurments.
-        bfield: pd.DataFrame
-            Vector mangetic field measurements.
-        rho: pd.Series
-            Mass density measurments, used to put `bfield` into Alfven units.
-        kwargs:
-            Passed to `rolling` method when mean-subtracing in `set_data`.
+        velocity : pandas.DataFrame
+            Plasma velocity in the same basis as ``bfield``.
+        bfield : pandas.DataFrame
+            Magnetic field in the same basis as ``velocity``.
+        rho : pandas.Series
+            Mass density used to normalise ``bfield``.
+        species : str
+            Species string used for the Alfvén-unit conversion.
+        **kwargs
+            Additional options forwarded to :meth:`set_data`.
         """
 
         super(AlfvenicTurbulence, self).__init__()

--- a/solarwindpy/fitfunctions/exponentials.py
+++ b/solarwindpy/fitfunctions/exponentials.py
@@ -16,7 +16,17 @@ from .core import FitFunction
 
 class Exponential(FitFunction):
     def __init__(self, xobs, yobs, **kwargs):
-        """Fit ``A * exp(-c x)`` to the data."""
+        """Fit ``A * exp(-c x)`` to the data.
+
+        Parameters
+        ----------
+        xobs : array-like
+            Independent variable values.
+        yobs : array-like
+            Observed dependent variable values.
+        **kwargs
+            Additional options forwarded to :class:`FitFunction`.
+        """
 
         super().__init__(xobs, yobs, **kwargs)
 
@@ -60,7 +70,17 @@ class Exponential(FitFunction):
 
 class ExponentialPlusC(FitFunction):
     def __init__(self, xobs, yobs, **kwargs):
-        """Fit ``A * exp(-c x) + d`` to the data."""
+        """Fit ``A * exp(-c x) + d`` to the data.
+
+        Parameters
+        ----------
+        xobs : array-like
+            Independent variable values.
+        yobs : array-like
+            Observed dependent variable values.
+        **kwargs
+            Additional options forwarded to :class:`FitFunction`.
+        """
 
         super().__init__(xobs, yobs, **kwargs)
 
@@ -105,7 +125,17 @@ class ExponentialPlusC(FitFunction):
 
 class ExponentialCDF(FitFunction):
     def __init__(self, xobs, yobs, **kwargs):
-        """Fit an exponential cumulative distribution function."""
+        """Fit an exponential cumulative distribution function.
+
+        Parameters
+        ----------
+        xobs : array-like
+            Independent variable values.
+        yobs : array-like
+            Observed cumulative counts.
+        **kwargs
+            Additional options forwarded to :class:`FitFunction`.
+        """
 
         super().__init__(xobs, yobs, **kwargs)
 

--- a/solarwindpy/instabilities/beta_ani.py
+++ b/solarwindpy/instabilities/beta_ani.py
@@ -29,6 +29,20 @@ class BetaRPlot(swp.plotting.histograms.Hist2D):
     """
 
     def __init__(self, beta, ani, species, **kwargs):
+        """Instantiate the histogram plot.
+
+        Parameters
+        ----------
+        beta : pandas.Series
+            Proton parallel beta.
+        ani : pandas.Series
+            Temperature anisotropy.
+        species : str
+            Label used to generate axis titles.
+        **kwargs
+            Additional options forwarded to :class:`Hist2D`.
+        """
+
         x = beta
         y = ani
 

--- a/solarwindpy/plotting/hist1d.py
+++ b/solarwindpy/plotting/hist1d.py
@@ -47,28 +47,28 @@ class Hist1D(AggPlot):
         nbins=101,
         bin_precision=None,
     ):
-        r"""
+        """Create a one-dimensional histogram.
+
         Parameters
         ----------
-        x: pd.Series
+        x : pandas.Series
             Data from which to create bins.
-        y: pd.Series, None
-            If not None, the values to aggregate in bins of `x`. If None,
-            aggregate counts of `x`.
-        logx: bool
-            If True, compute bins in log-space.
-        axnorm: None, str
-        Normalize the histogram.
-            key  normalization
-            ---  -------------
-            t    total
-            d    density
-        clip_data: bool
-            If True, remove the extreme values at 0.001 and 0.999 percentiles
-            before calculating bins or aggregating.
-        nbins: int, str, array-like
-            Dispatched to `np.histogram_bin_edges` or `pd.cut` depending on
-            input type and value.
+        y : pandas.Series or None, optional
+            Values to aggregate in bins of ``x``. If ``None``, counts of
+            ``x`` are used.
+        logx : bool, optional
+            If ``True``, compute bins in logarithmic space.
+        axnorm : {"t", "d", None}, optional
+            Normalisation applied to the histogram. ``"t"`` uses total
+            counts and ``"d"`` yields a density.
+        clip_data : bool, optional
+            Remove extreme values at the 0.001 and 0.999 percentiles before
+            binning or aggregation.
+        nbins : int or array-like, optional
+            Binning strategy passed to :func:`numpy.histogram_bin_edges` or
+            :func:`pandas.cut` depending on the input type.
+        bin_precision : int, optional
+            Precision for decimal bin edges.
         """
         super(Hist1D, self).__init__()
         self.set_log(x=logx)


### PR DESCRIPTION
## Summary
- add napoleon and autosummary to Sphinx config and derive version from package
- enforce D205 and D406 docstring checks in flake8 config
- convert assorted docstrings to NumPy style across core, fitfunctions, instabilities, and plotting modules

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68919e78a4f0832cbc14410e6ef5a411