### PR TITLE
test(fitfunctions): add mask xmin only case

### DIFF
--- a/tests/fitfunctions/test_core.py
+++ b/tests/fitfunctions/test_core.py
@@ -44,6 +44,8 @@ def test_build_one_obs_mask():
     assert np.array_equal(mask, np.array([False, True, False, False]))
     mask = lf._build_one_obs_mask("xobs", x, None, 1.5)
     assert np.array_equal(mask, np.array([True, True, False, False]))
+    mask = lf._build_one_obs_mask("xobs", x, 0.5, None)
+    assert np.array_equal(mask, np.array([False, True, True, False]))
 
 
 def test_build_outside_mask():


### PR DESCRIPTION
## Summary
- add test for `_build_one_obs_mask` handling `xmin` only

## Testing
- `black tests/fitfunctions/test_core.py`
- `flake8 tests/fitfunctions/test_core.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891a3dfae78832c981f6a8b73f2d07c