### PR TITLE
docs: add installation and usage guides

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -1,0 +1,9 @@
+API Reference
+=============
+
+The complete API documentation is generated from the source code.
+
+.. toctree::
+   :maxdepth: 1
+
+   solarwindpy

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,12 +3,14 @@ SolarWindPy Docs
 ################
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 2
    :caption: Contents:
-      
+
+   installation
+   usage
+   tutorial
+   api_reference
    modules
-   tutorial/quickstart
-   solarwindpy.solar_activity.tests
 
 .. include:: ../../LICENSE.rst
 .. include:: ../../CITATION.rst

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,0 +1,24 @@
+Installation
+============
+
+SolarWindPy requires Python 3.11 or later. The package can be installed from
+PyPI using :command:`pip`:
+
+.. code-block:: bash
+
+   pip install solarwindpy
+
+To work with the latest development version, clone the repository and install
+its dependencies:
+
+.. code-block:: bash
+
+   git clone https://github.com/space-python/SolarWindPy.git
+   cd SolarWindPy
+   pip install -r requirements.txt
+
+For contributors, install the additional development tools:
+
+.. code-block:: bash
+
+   pip install -r requirements-dev.txt

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,7 +1,12 @@
-solarwindpy
-===========
+SolarWindPy Modules
+===================
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 1
 
-   solarwindpy
+   solarwindpy.core
+   solarwindpy.tools
+   solarwindpy.fitfunctions
+   solarwindpy.instabilities
+   solarwindpy.plotting
+   solarwindpy.solar_activity

--- a/docs/source/solarwindpy.core.rst
+++ b/docs/source/solarwindpy.core.rst
@@ -8,71 +8,70 @@ solarwindpy.core.alfvenic\_turbulence module
 --------------------------------------------
 
 .. automodule:: solarwindpy.core.alfvenic_turbulence
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.core.base module
 ----------------------------
 
 .. automodule:: solarwindpy.core.base
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.core.ions module
 ----------------------------
 
 .. automodule:: solarwindpy.core.ions
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.core.plasma module
 ------------------------------
 
 .. automodule:: solarwindpy.core.plasma
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.core.spacecraft module
 ----------------------------------
 
 .. automodule:: solarwindpy.core.spacecraft
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.core.tensor module
 ------------------------------
 
 .. automodule:: solarwindpy.core.tensor
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.core.units\_constants module
 ----------------------------------------
 
 .. automodule:: solarwindpy.core.units_constants
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.core.vector module
 ------------------------------
 
 .. automodule:: solarwindpy.core.vector
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: solarwindpy.core
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/solarwindpy.fitfunctions.rst
+++ b/docs/source/solarwindpy.fitfunctions.rst
@@ -8,47 +8,70 @@ solarwindpy.fitfunctions.core module
 ------------------------------------
 
 .. automodule:: solarwindpy.fitfunctions.core
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.fitfunctions.exponentials module
 --------------------------------------------
 
 .. automodule:: solarwindpy.fitfunctions.exponentials
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.fitfunctions.gaussians module
 -----------------------------------------
 
 .. automodule:: solarwindpy.fitfunctions.gaussians
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.fitfunctions.lines module
 -------------------------------------
 
 .. automodule:: solarwindpy.fitfunctions.lines
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.fitfunctions.plots module
+-------------------------------------
+
+.. automodule:: solarwindpy.fitfunctions.plots
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.fitfunctions.power\_laws module
+-------------------------------------------
+
+.. automodule:: solarwindpy.fitfunctions.power_laws
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.fitfunctions.tex\_info module
+-----------------------------------------
+
+.. automodule:: solarwindpy.fitfunctions.tex_info
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.fitfunctions.trend\_fits module
 -------------------------------------------
 
 .. automodule:: solarwindpy.fitfunctions.trend_fits
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: solarwindpy.fitfunctions
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/solarwindpy.instabilities.rst
+++ b/docs/source/solarwindpy.instabilities.rst
@@ -8,23 +8,22 @@ solarwindpy.instabilities.beta\_ani module
 ------------------------------------------
 
 .. automodule:: solarwindpy.instabilities.beta_ani
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.instabilities.verscharen2016 module
 -----------------------------------------------
 
 .. automodule:: solarwindpy.instabilities.verscharen2016
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: solarwindpy.instabilities
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/solarwindpy.plans.rst
+++ b/docs/source/solarwindpy.plans.rst
@@ -1,0 +1,21 @@
+solarwindpy.plans package
+=========================
+
+Submodules
+----------
+
+solarwindpy.plans.issues\_from\_plans module
+--------------------------------------------
+
+.. automodule:: solarwindpy.plans.issues_from_plans
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: solarwindpy.plans
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/solarwindpy.plotting.labels.rst
+++ b/docs/source/solarwindpy.plotting.labels.rst
@@ -8,23 +8,54 @@ solarwindpy.plotting.labels.base module
 ---------------------------------------
 
 .. automodule:: solarwindpy.plotting.labels.base
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.plotting.labels.chemistry module
+--------------------------------------------
+
+.. automodule:: solarwindpy.plotting.labels.chemistry
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.plotting.labels.composition module
+----------------------------------------------
+
+.. automodule:: solarwindpy.plotting.labels.composition
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.plotting.labels.datetime module
+-------------------------------------------
+
+.. automodule:: solarwindpy.plotting.labels.datetime
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.plotting.labels.elemental\_abundance module
+-------------------------------------------------------
+
+.. automodule:: solarwindpy.plotting.labels.elemental_abundance
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.plotting.labels.special module
 ------------------------------------------
 
 .. automodule:: solarwindpy.plotting.labels.special
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: solarwindpy.plotting.labels
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/solarwindpy.plotting.rst
+++ b/docs/source/solarwindpy.plotting.rst
@@ -5,57 +5,97 @@ Subpackages
 -----------
 
 .. toctree::
+   :maxdepth: 4
 
-    solarwindpy.plotting.labels
+   solarwindpy.plotting.labels
 
 Submodules
 ----------
+
+solarwindpy.plotting.agg\_plot module
+-------------------------------------
+
+.. automodule:: solarwindpy.plotting.agg_plot
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.plotting.base module
 --------------------------------
 
 .. automodule:: solarwindpy.plotting.base
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.plotting.hist1d module
+----------------------------------
+
+.. automodule:: solarwindpy.plotting.hist1d
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.plotting.hist2d module
+----------------------------------
+
+.. automodule:: solarwindpy.plotting.hist2d
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.plotting.histograms module
 --------------------------------------
 
 .. automodule:: solarwindpy.plotting.histograms
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.plotting.orbits module
 ----------------------------------
 
 .. automodule:: solarwindpy.plotting.orbits
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.plotting.scatter module
 -----------------------------------
 
 .. automodule:: solarwindpy.plotting.scatter
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.plotting.select\_data\_from\_figure module
+------------------------------------------------------
+
+.. automodule:: solarwindpy.plotting.select_data_from_figure
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.plotting.spiral module
+----------------------------------
+
+.. automodule:: solarwindpy.plotting.spiral
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.plotting.tools module
 ---------------------------------
 
 .. automodule:: solarwindpy.plotting.tools
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: solarwindpy.plotting
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/solarwindpy.rst
+++ b/docs/source/solarwindpy.rst
@@ -5,19 +5,22 @@ Subpackages
 -----------
 
 .. toctree::
+   :maxdepth: 4
 
-    solarwindpy.core
-    solarwindpy.fitfunctions
-    solarwindpy.instabilities
-    solarwindpy.plotting
-    solarwindpy.solar_activity
-    solarwindpy.tests
-    solarwindpy.tools
+   solarwindpy.core
+   solarwindpy.fitfunctions
+   solarwindpy.instabilities
+   solarwindpy.plans
+   solarwindpy.plotting
+   solarwindpy.scripts
+   solarwindpy.solar_activity
+   solarwindpy.tests
+   solarwindpy.tools
 
 Module contents
 ---------------
 
 .. automodule:: solarwindpy
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/solarwindpy.scripts.rst
+++ b/docs/source/solarwindpy.scripts.rst
@@ -1,0 +1,10 @@
+solarwindpy.scripts package
+===========================
+
+Module contents
+---------------
+
+.. automodule:: solarwindpy.scripts
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/solarwindpy.solar_activity.lisird.rst
+++ b/docs/source/solarwindpy.solar_activity.lisird.rst
@@ -8,23 +8,22 @@ solarwindpy.solar\_activity.lisird.extrema\_calculator module
 -------------------------------------------------------------
 
 .. automodule:: solarwindpy.solar_activity.lisird.extrema_calculator
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.solar\_activity.lisird.lisird module
 ------------------------------------------------
 
 .. automodule:: solarwindpy.solar_activity.lisird.lisird
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: solarwindpy.solar_activity.lisird
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/solarwindpy.solar_activity.rst
+++ b/docs/source/solarwindpy.solar_activity.rst
@@ -5,9 +5,10 @@ Subpackages
 -----------
 
 .. toctree::
+   :maxdepth: 4
 
-    solarwindpy.solar_activity.lisird
-    solarwindpy.solar_activity.sunspot_number
+   solarwindpy.solar_activity.lisird
+   solarwindpy.solar_activity.sunspot_number
 
 Submodules
 ----------
@@ -16,23 +17,22 @@ solarwindpy.solar\_activity.base module
 ---------------------------------------
 
 .. automodule:: solarwindpy.solar_activity.base
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.solar\_activity.plots module
 ----------------------------------------
 
 .. automodule:: solarwindpy.solar_activity.plots
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: solarwindpy.solar_activity
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/solarwindpy.solar_activity.sunspot_number.rst
+++ b/docs/source/solarwindpy.solar_activity.sunspot_number.rst
@@ -8,15 +8,14 @@ solarwindpy.solar\_activity.sunspot\_number.sidc module
 -------------------------------------------------------
 
 .. automodule:: solarwindpy.solar_activity.sunspot_number.sidc
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: solarwindpy.solar_activity.sunspot_number
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/solarwindpy.tests.rst
+++ b/docs/source/solarwindpy.tests.rst
@@ -4,59 +4,114 @@ solarwindpy.tests package
 Submodules
 ----------
 
+solarwindpy.tests.conftest module
+---------------------------------
+
+.. automodule:: solarwindpy.tests.conftest
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 solarwindpy.tests.test\_alfvenic\_turbulence module
 ---------------------------------------------------
 
 .. automodule:: solarwindpy.tests.test_alfvenic_turbulence
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.tests.test\_base module
 -----------------------------------
 
 .. automodule:: solarwindpy.tests.test_base
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.tests.test\_base\_head\_tail module
+-----------------------------------------------
+
+.. automodule:: solarwindpy.tests.test_base_head_tail
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.tests.test\_base\_mi\_tuples module
+-----------------------------------------------
+
+.. automodule:: solarwindpy.tests.test_base_mi_tuples
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.tests.test\_core\_verify\_datetimeindex module
+----------------------------------------------------------
+
+.. automodule:: solarwindpy.tests.test_core_verify_datetimeindex
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.tests.test\_ions module
 -----------------------------------
 
 .. automodule:: solarwindpy.tests.test_ions
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.tests.test\_issue\_titles module
+--------------------------------------------
+
+.. automodule:: solarwindpy.tests.test_issue_titles
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.tests.test\_plasma module
 -------------------------------------
 
 .. automodule:: solarwindpy.tests.test_plasma
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+solarwindpy.tests.test\_plasma\_io module
+-----------------------------------------
+
+.. automodule:: solarwindpy.tests.test_plasma_io
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.tests.test\_quantities module
 -----------------------------------------
 
 .. automodule:: solarwindpy.tests.test_quantities
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 solarwindpy.tests.test\_spacecraft module
 -----------------------------------------
 
 .. automodule:: solarwindpy.tests.test_spacecraft
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
+solarwindpy.tests.test\_units\_constants module
+-----------------------------------------------
+
+.. automodule:: solarwindpy.tests.test_units_constants
+   :members:
+   :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: solarwindpy.tests
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/solarwindpy.tools.rst
+++ b/docs/source/solarwindpy.tools.rst
@@ -5,6 +5,6 @@ Module contents
 ---------------
 
 .. automodule:: solarwindpy.tools
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -1,0 +1,9 @@
+Tutorial
+========
+
+This section walks through a short example using SolarWindPy.
+
+.. toctree::
+   :maxdepth: 1
+
+   tutorial/quickstart

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,0 +1,18 @@
+Usage
+=====
+
+The library exposes a set of tools for manipulating solar wind data. After
+installation, import the desired functions and classes:
+
+.. code-block:: python
+
+   from solarwindpy.core import Plasma
+   from solarwindpy.tools import normal_parameters
+   import numpy as np
+
+   m = np.array([0.1, 0.2])
+   s = np.array([0.05, 0.08])
+   params = normal_parameters(m, s)
+   print(params.head())
+
+See the :doc:`tutorial` for a guided introduction and more examples.


### PR DESCRIPTION
## Summary
- add installation, usage, tutorial, and API reference pages
- outline key SolarWindPy modules in documentation
- regenerate and include API documentation stubs

## Testing
- `sphinx-build -b html docs/source docs/_build/html`
- `black --check .` *(fails: would reformat files)*
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891a3bcbd04832c9b31ef711d0a1647