### PR TITLE
ci(docs): add doc build and deployment workflows

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,29 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r docs/requirements.txt
+          pip install .
+      - name: Build documentation
+        env:
+          SPHINXOPTS: -W
+        working-directory: docs
+        run: make html
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -1,0 +1,25 @@
+name: Docs Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -r docs/requirements.txt
+          pip install .
+      - name: Build documentation
+        env:
+          SPHINXOPTS: -W
+        working-directory: docs
+        run: make html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+python:
+  install:
+    - requirements: requirements.txt
+    - requirements: docs/requirements.txt
+
+sphinx:
+  configuration: docs/source/conf.py

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,13 @@ Development
 
    This will run ``black`` and ``flake8`` automatically when committing.
 
+6. Build the documentation and fail on warnings:
+
+   .. code-block:: bash
+
+      cd docs
+      make html SPHINXOPTS=-W
+
 
 License
 =======


### PR DESCRIPTION
## Summary
- build docs in CI with warnings treated as errors
- deploy built docs to gh-pages
- configure Read the Docs and document local doc builds

## Testing
- `black --check .` *(fails: would reformat solarwindpy/fitfunctions/__init__.py)*
- `flake8`
- `pytest -q`
- `make html SPHINXOPTS=-W` *(fails: 90 warnings treated as errors)*

------
https://chatgpt.com/codex/tasks/task_e_6891a8b9d600832c9c25e5850574b9a9