### PR TITLE
docs(core): use raw string for e_plus docstring

### DIFF
--- a/solarwindpy/core/alfvenic_turbulence.py
+++ b/solarwindpy/core/alfvenic_turbulence.py
@@ -142,7 +142,7 @@ class AlfvenicTurbulence(base.Core):
 
     @property
     def e_plus(self):
-        """Energy contained in :math:`z^+`."""
+        r"""Energy contained in :math:`z^+`."""
         ep = 0.5 * self.zp.pow(2).sum(axis=1)
         return ep
 


### PR DESCRIPTION
## Summary
- mark `e_plus` docstring as a raw string

## Testing
- `black solarwindpy/core/alfvenic_turbulence.py`
- `flake8 solarwindpy/core/alfvenic_turbulence.py`
- `NUMBA_CPU_NAME=generic pytest -q` *(fails: AttributeError: module 'llvmlite.binding' has no attribute 'ffi')*

------
https://chatgpt.com/codex/tasks/task_e_6891bb71d5cc832cb6f6647cbae8b465