### PR TITLE
feat(fitfunctions): default labels for TrendFit

### DIFF
--- a/solarwindpy/fitfunctions/core.py
+++ b/solarwindpy/fitfunctions/core.py
@@ -35,7 +35,9 @@ from scipy.optimize._lsq.least_squares import prepare_bounds
 from scipy.linalg import svd, cholesky, LinAlgError
 
 from .tex_info import TeXinfo
-from .plots import FFPlot
+from .plots import FFPlot, AxesLabels as _AxesLabels
+
+AxesLabels = _AxesLabels
 
 Observations = namedtuple("Observations", "x,y,w")
 UsedRawObs = namedtuple("UsedRawObs", "used,raw,tk_observed")

--- a/solarwindpy/fitfunctions/trend_fits.py
+++ b/solarwindpy/fitfunctions/trend_fits.py
@@ -62,8 +62,7 @@ class TrendFit(object):
         self.set_fitfunctions(ffunc1d, trendfunc)
         self._trend_logx = bool(trend_logx)
         self._popt1d_keys = Popt1DKeys(ykey1d, wkey1d)
-
-    #         self._labels = core.AxesLabels(x="x", y="y", z=swp.pp.labels.Count())
+        self._labels = core.AxesLabels(x="x", y="y", z=swp.pp.labels.Count())
 
     def __str__(self):
         return self.__class__.__name__
@@ -411,7 +410,8 @@ class TrendFit(object):
         tf = self.trend_func
         tf.plotter.set_labels(**kwargs)
 
-        y = tf.plotter.labels.y
-        z = tf.plotter.labels.z
-        for k, ff in self.ffuncs.items():
-            ff.plotter.set_labels(x=y, y=z)
+        lbls = tf.plotter.labels
+        self._labels = core.AxesLabels(lbls.x, lbls.y, lbls.z)
+
+        for ff in self.ffuncs.values:
+            ff.plotter.set_labels(x=lbls.y, y=lbls.z)

--- a/tests/fitfunctions/test_trend_fits.py
+++ b/tests/fitfunctions/test_trend_fits.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from scipy.optimize import OptimizeWarning
 
-from solarwindpy.fitfunctions import gaussians, trend_fits, lines
+from solarwindpy.fitfunctions import core, gaussians, trend_fits, lines
 
 
 @pytest.fixture
@@ -117,3 +117,9 @@ def test_set_agged_set_fitfunctions_set_shared_labels(trend_fit, agged):
     first_ff = trend_fit.ffuncs.iloc[0]
     assert first_ff.plotter.labels.x == "density"
     assert first_ff.plotter.labels.y == "counts"
+
+
+def test_labels_instance_and_update(trend_fit):
+    assert isinstance(trend_fit.labels, core.AxesLabels)
+    trend_fit.set_shared_labels(x="time", y="density", z="counts")
+    assert trend_fit.labels == core.AxesLabels("time", "density", "counts")


### PR DESCRIPTION
## Summary
- export `AxesLabels` from `fitfunctions.core`
- default `TrendFit` labels and update via `set_shared_labels`
- test `TrendFit.labels` initialization and update

## Testing
- `python -m black solarwindpy/fitfunctions/trend_fits.py`
- `python -m flake8 solarwindpy/fitfunctions/core.py solarwindpy/fitfunctions/trend_fits.py tests/fitfunctions/test_trend_fits.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891ba0930a0832c8aeba2559a7fa21c