### PR TITLE
test(trend_fits): add non-DataFrame assertion for set_agged

### DIFF
--- a/tests/fitfunctions/test_trend_fits.py
+++ b/tests/fitfunctions/test_trend_fits.py
@@ -119,6 +119,11 @@ def test_set_agged_set_fitfunctions_set_shared_labels(trend_fit, agged):
     assert first_ff.plotter.labels.y == "counts"
 
 
+def test_set_agged_rejects_non_dataframe(trend_fit):
+    with pytest.raises(AssertionError):
+        trend_fit.set_agged(42)
+
+
 def test_labels_instance_and_update(trend_fit):
     assert isinstance(trend_fit.labels, core.AxesLabels)
     trend_fit.set_shared_labels(x="time", y="density", z="counts")


### PR DESCRIPTION
## Summary
- test `TrendFit.set_agged` rejects non-DataFrame input

## Testing
- `flake8 tests/fitfunctions/test_trend_fits.py`
- `black tests/fitfunctions/test_trend_fits.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891be47de98832c95298d0d23a9757b