### PR TITLE
test(plotting): assert helpers return axes

### DIFF
--- a/solarwindpy/tests/plotting/test_tools.py
+++ b/solarwindpy/tests/plotting/test_tools.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""Tests for plotting helpers."""
+
+from matplotlib import pyplot as plt
+from matplotlib.figure import Figure
+from matplotlib.axes import Axes
+
+from solarwindpy.plotting import tools
+import solarwindpy.plotting as plotting
+
+
+def test_subplots_returns_axes(monkeypatch):
+    """subplots should return a matplotlib Axes object."""
+
+    fig = Figure()
+    ax = fig.add_subplot(111)
+
+    def dummy_subplots(*args, **kwargs):
+        return fig, ax
+
+    monkeypatch.setattr(plt, "subplots", dummy_subplots)
+
+    fig_tools, ax_tools = tools.subplots()
+    assert isinstance(ax_tools, Axes)
+    assert ax_tools is ax
+
+    fig_pkg, ax_pkg = plotting.subplots()
+    assert isinstance(ax_pkg, Axes)
+    assert ax_pkg is ax


### PR DESCRIPTION
## Summary
- add regression test to confirm plotting `subplots` helpers produce matplotlib axes

## Testing
- `black solarwindpy/tests/plotting/test_tools.py`
- `flake8 solarwindpy/tests/plotting/test_tools.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891be4689f0832cbd62a42c37284dbd