### PR TITLE
docs: standardize math markup in docstrings

### DIFF
--- a/solarwindpy/core/alfvenic_turbulence.py
+++ b/solarwindpy/core/alfvenic_turbulence.py
@@ -34,7 +34,7 @@ AlvenicTurbAveraging = namedtuple("AlvenicTurbAveraging", "window,min_periods")
 
 
 class AlfvenicTurbulence(base.Core):
-    r"""Alfv\'enic turbulence diagnostics using Elsasser variables.
+    """Alfvénic turbulence diagnostics using Elsasser variables.
 
     Parameters
     ----------
@@ -45,7 +45,7 @@ class AlfvenicTurbulence(base.Core):
     rho : :class:`pandas.Series`
         Mass density used for normalising ``bfield``.
     species : str
-        Species string used when converting to Alfv\'en units.
+        Species string used when converting to Alfvén units.
 
     Notes
     -----

--- a/solarwindpy/fitfunctions/gaussians.py
+++ b/solarwindpy/fitfunctions/gaussians.py
@@ -236,11 +236,11 @@ class GaussianLn(FitFunction):
 
     @property
     def TeX_popt(self):
-        r"""
-        Create a dictionary with (k, v) pairs corresponding to
-        (self.argnames, popt \pm psigma) with the appropriate uncertainty.
+        r"""Create a dictionary with ``(k, v)`` pairs corresponding to
+        ``(self.argnames, :math:`p_{\mathrm{opt}} \pm \sigma_p`)`` with the
+        appropriate uncertainty.
 
-        See self.set_TeX_trans_argnames to translate the argnames for TeX.
+        See ``set_TeX_trans_argnames`` to translate the argnames for TeX.
         """
         TeX_popt = super(GaussianLn, self).TeX_popt
 

--- a/solarwindpy/fitfunctions/gaussians.py
+++ b/solarwindpy/fitfunctions/gaussians.py
@@ -123,7 +123,7 @@ class GaussianNormalized(FitFunction):
 
 
 class GaussianLn(FitFunction):
-    r"""Gaussian where taking `$ln(x)$`.
+    r"""Gaussian where taking :math:`\ln(x)`.
 
     [1] https://mathworld.wolfram.com/LogNormalDistribution.html
     """
@@ -207,8 +207,10 @@ class GaussianLn(FitFunction):
     def normal_parameters(self):
         r"""Calculate the normal parameters from log-normal parameters.
 
-        $\mu = \exp[m + (s^2)/2]$
-        $\sigma = \sqrt{ \exp[s^2 + 2m] (\exp[s^2] - 1)}$
+        .. math::
+
+            \mu = \exp[m + (s^2)/2]
+            \sigma = \sqrt{\exp[s^2 + 2m] (\exp[s^2] - 1)}
         """
         m = self.popt["m"]
         s = self.popt["s"]

--- a/solarwindpy/fitfunctions/tex_info.py
+++ b/solarwindpy/fitfunctions/tex_info.py
@@ -178,11 +178,9 @@ class TeXinfo(object):
 
     @staticmethod
     def _check_and_add_math_escapes(x):
-        r"""
-        Add "$" math escapes to a string.
+        r"""Add dollar-sign math escapes to a string.
 
-        This function can probably be turned into a
-        static method.
+        This function can probably be turned into a static method.
         """
         assert isinstance(x, str)
         if not x.count("$"):

--- a/solarwindpy/fitfunctions/tex_info.py
+++ b/solarwindpy/fitfunctions/tex_info.py
@@ -131,10 +131,11 @@ class TeXinfo(object):
 
     @property
     def TeX_popt(self):
-        r"""Create a dictionary with (k, v) pairs corresponding to
-        (self.argnames, popt \pm psigma) with the appropriate uncertainty.
+        r"""Create a dictionary with ``(k, v)`` pairs corresponding to
+        ``(self.argnames, :math:`p_{\mathrm{opt}} \pm \sigma_p`)`` with the
+        appropriate uncertainty.
 
-        See `set_TeX_trans_argnames` to translate the argnames for TeX.
+        See ``set_TeX_trans_argnames`` to translate the argnames for TeX.
         """
         psigma = self.psigma
         popt = self.popt.items()
@@ -532,14 +533,15 @@ class TeXinfo(object):
         self._rsq = new
 
     def val_uncert_2_string(self, value, uncertainty):
-        r"""
-        Convert a value, uncertainty pair to a string in which the
-        value is reported to the first non-zero digit of the uncertainty.
+        r"""Convert a value, uncertainty pair to a string where the value is
+        reported to the first non-zero digit of the uncertainty.
 
-        Require that value > uncertainty.
+        Require that ``value > uncertainty``.
 
-        Example
-        -------
+        Examples
+        --------
+        The generated string uses :math:`\pm` to denote the uncertainty.
+
         >>> a = 3.1415
         >>> b = 0.01
         >>> val_uncert_2_string(a, b)

--- a/solarwindpy/plotting/hist2d.py
+++ b/solarwindpy/plotting/hist2d.py
@@ -494,7 +494,7 @@ class Hist2D(base.PlotWithZdata, base.CbarMaker, AggPlot):
         return ax.plot(x, y, **kwargs)
 
     def plot_edges(self, ax, smooth=True, sg_kwargs=None, **kwargs):
-        r"""Overplot the edges.
+        """Overplot the edges.
 
         Parameters
         ----------
@@ -506,8 +506,8 @@ class Hist2D(base.PlotWithZdata, base.CbarMaker, AggPlot):
         sg_kwargs: dict, None
             If not None, dict of kwargs passed to Savitzky-Golay filter. Also allows
             for setting of `window_length` and `polyorder` as kwargs. They default to
-            10\% of the number of observations (`window_length`) and 3 (`polyorder`).
-            Note that because `window_length` must be odd, if the 10\% value is even, we
+            10% of the number of observations (`window_length`) and 3 (`polyorder`).
+            Note that because `window_length` must be odd, if the 10% value is even, we
             take 1-window_length.
         kwargs:
             Passed to `ax.plot`

--- a/solarwindpy/plotting/labels/base.py
+++ b/solarwindpy/plotting/labels/base.py
@@ -472,12 +472,17 @@ class TeXlabel(Base):
         self._axnorm = new
 
     def make_species(self, pattern):
-        r"""Basic substitution of any species within a species string so long
-        as the species has a substitution in the ion_species dictionary.
-        Note: this equation might only work because a->\alpha is the only
-        actual translation made and, based on lexsort order, would be the
-        first group. This function may need to be updated for more complex
-        patterns, e.g. if we translate something like He2+->\text{He}^{2+}."""
+        r"""Basic substitution of any species within a species string if the
+        species has a substitution in the ion_species dictionary.
+
+        Notes
+        -----
+        This equation might only work because :math:`a\rightarrow\alpha` is
+        the only actual translation made and, based on lexsort order, would be
+        the first group. This function may need to be updated for more complex
+        patterns, e.g., if we translate something like
+        :math:`\mathrm{He}^{2+}\rightarrow\text{He}^{2+}`.
+        """
 
         #         def repl(x):
         #             return _trans_species[x.group()]

--- a/solarwindpy/solar_activity/base.py
+++ b/solarwindpy/solar_activity/base.py
@@ -379,7 +379,7 @@ class IndicatorExtrema(Base):
 
     @property
     def extrema_bands(self):
-        r"""Bands of time (``\Delta t``) about indicator extrema.
+        r"""Bands of time (:math:`\Delta t`) about indicator extrema.
 
         Parameters
         ----------


### PR DESCRIPTION
## Summary
- use Sphinx math directive in GaussianLn description
- format normal parameter equations with a math block
- render Δt with :math: in solar activity extrema bands docstring

## Testing
- `pip install --break-system-packages -r requirements-dev.txt`
- `pip install --break-system-packages requests`
- `pip install --break-system-packages tables`
- `black solarwindpy/fitfunctions/gaussians.py solarwindpy/solar_activity/base.py`
- `flake8 solarwindpy/fitfunctions/gaussians.py solarwindpy/solar_activity/base.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891bb9e6c2c832c9b0c3827fdcd6232