### PR TITLE
test(tex_info): verify TeX argnames mapping

### DIFF
--- a/tests/fitfunctions/test_tex_info.py
+++ b/tests/fitfunctions/test_tex_info.py
@@ -33,6 +33,7 @@ def test_properties_and_str(texinfo):
     assert texinfo.rsq == 0.99
     assert texinfo.npts == 10
     assert texinfo.TeX_function == "f(x)=a x + b"
+    assert texinfo.TeX_argnames == {"a": "\\alpha", "b": "\\beta"}
     assert "\\alpha" in texinfo.initial_guess_info
     assert texinfo.TeX_popt["\\alpha"].startswith("1.23")
     assert "\\sigma(X)/X" in texinfo.TeX_relative_error


### PR DESCRIPTION
## Summary
- ensure TeX argument names map to expected symbols in tex_info tests

## Testing
- `python -m black tests/fitfunctions/test_tex_info.py`
- `python -m flake8 tests/fitfunctions/test_tex_info.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891d1f138b0832c9ff8d605a13e3caf