### PR TITLE
fix(tex_info): validate kwargs in fit parameter builder

### DIFF
--- a/solarwindpy/fitfunctions/tex_info.py
+++ b/solarwindpy/fitfunctions/tex_info.py
@@ -259,8 +259,23 @@ class TeXinfo(object):
         simplify_info_for_paper=False,
         npts=False,
         relative_error=False,
+        **kwargs,
     ):
-        """Assemble the formatted lines describing the fit."""
+        r"""Assemble the formatted lines describing the fit.
+
+        Parameters
+        ----------
+        **kwargs
+            Unused keyword arguments.
+
+        Raises
+        ------
+        ValueError
+            If ``kwargs`` contains any entries.
+        """
+
+        if kwargs:
+            raise ValueError(f"Unused kwargs {kwargs.keys()}")
 
         TeX_function = self.TeX_function
         TeX_popt = self.TeX_popt

--- a/tests/fitfunctions/test_tex_info.py
+++ b/tests/fitfunctions/test_tex_info.py
@@ -98,6 +98,12 @@ def test_build_fit_parameter_info(texinfo):
     assert "N_\\mathrm{pts}" in info and "sigma(X)/X" in info
 
 
+def test_build_fit_parameter_info_errors(texinfo):
+    """_build_fit_parameter_info should reject unknown kwargs."""
+    with pytest.raises(ValueError):
+        texinfo._build_fit_parameter_info(bogus=True)
+
+
 def test_annotate_info(texinfo):
     import matplotlib.pyplot as plt
 


### PR DESCRIPTION
## Summary
- ensure `_build_fit_parameter_info` rejects unexpected keyword arguments
- add regression test for bogus kwargs

## Testing
- `flake8 tests/fitfunctions/test_tex_info.py solarwindpy/fitfunctions/tex_info.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891d1f1c87c832c927f3cee6f24ff71