### PR TITLE
fix(tex_info): validate setter inputs

### DIFF
--- a/solarwindpy/fitfunctions/tex_info.py
+++ b/solarwindpy/fitfunctions/tex_info.py
@@ -498,6 +498,10 @@ class TeXinfo(object):
         self._npts = new
 
     def set_popt_psigma(self, popt, psigma):
+        if not isinstance(popt, dict):
+            raise TypeError(f"'popt' must be a dict, not {type(popt)}")
+        if not isinstance(psigma, dict):
+            raise TypeError(f"'psigma' must be a dict, not {type(psigma)}")
         for k in popt:
             if k not in psigma:
                 raise ValueError(f"key ({k}) must be in both 'popt' and 'psigma' ")
@@ -523,12 +527,22 @@ class TeXinfo(object):
         self._TeX_argnames = kwargs.items()
 
     def set_TeX_function(self, TeX_function):
+        if not isinstance(TeX_function, str):
+            raise TypeError(f"'TeX_function' must be a str, not {type(TeX_function)}")
         self._TeX_function = TeX_function
 
     def set_chisq_dof(self, new):
+        if new is not None and not (
+            isinstance(new, Number)
+            or hasattr(new, "__dict__")
+            or isinstance(new, tuple)
+        ):
+            raise TypeError(f"Unexpected chisq_dof type ({type(new)})")
         self._chisq_dof = new
 
     def set_rsq(self, new):
+        if new is not None and not isinstance(new, Number):
+            raise TypeError(f"Unexpected rsq type ({type(new)})")
         self._rsq = new
 
     def val_uncert_2_string(self, value, uncertainty):

--- a/tests/fitfunctions/test_tex_info.py
+++ b/tests/fitfunctions/test_tex_info.py
@@ -55,6 +55,30 @@ def test_constructor_and_setters_errors():
         tex.set_TeX_argnames(c="\\gamma")
 
 
+def test_set_popt_psigma_errors(texinfo):
+    with pytest.raises(TypeError):
+        texinfo.set_popt_psigma("bad", {"a": 1})
+    with pytest.raises(TypeError):
+        texinfo.set_popt_psigma({"a": 1}, "bad")
+    with pytest.raises(ValueError):
+        texinfo.set_popt_psigma({"a": 1}, {"b": 1})
+
+
+def test_set_chisq_dof_type_error(texinfo):
+    with pytest.raises(TypeError):
+        texinfo.set_chisq_dof("bad")
+
+
+def test_set_rsq_type_error(texinfo):
+    with pytest.raises(TypeError):
+        texinfo.set_rsq("bad")
+
+
+def test_set_TeX_function_type_error(texinfo):
+    with pytest.raises(TypeError):
+        texinfo.set_TeX_function(5)
+
+
 def test_check_and_add_math_escapes():
     f = TeXinfo._check_and_add_math_escapes
     assert f("x") == "$x$"


### PR DESCRIPTION
## Summary
- enforce dict and str checks in TeXinfo setters
- guard chisq_dof and rsq against invalid types
- test setter error paths

## Testing
- `flake8 solarwindpy/fitfunctions/tex_info.py tests/fitfunctions/test_tex_info.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891d2010258832c86673da1567950c2