### PR TITLE
test(fitfunctions): assert mismatch in set_observations

### DIFF
--- a/tests/fitfunctions/test_plots.py
+++ b/tests/fitfunctions/test_plots.py
@@ -85,6 +85,14 @@ def test_setters():
     assert np.all(plot.y_fit == y_fit2)
 
 
+def test_set_observations_mismatched_length():
+    plot, *_ = make_ffplot()
+    obs = plot.observations
+    bad_y_fit = np.ones(obs.raw.x.size + 1)
+    with pytest.raises(AssertionError):
+        plot.set_observations(obs, bad_y_fit)
+
+
 def test_estimate_markevery():
     plot, *_ = make_ffplot(n=5)
     assert plot._estimate_markevery() is None


### PR DESCRIPTION
## Summary
- test that FFPlot.set_observations raises AssertionError when y_fit length mismatches

## Testing
- `black tests/fitfunctions/test_plots.py`
- `flake8 tests/fitfunctions/test_plots.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689232768008832c88003feaf87303e2