### PR TITLE
fix(texinfo): wrap string additional info

### DIFF
--- a/solarwindpy/fitfunctions/tex_info.py
+++ b/solarwindpy/fitfunctions/tex_info.py
@@ -240,12 +240,11 @@ class TeXinfo(object):
             ):
                 for i, this_info in enumerate(additional_info):
                     additional_info[i] = self._check_and_add_math_escapes(this_info)
-
                 additional_info = "\n".join(additional_info)
-                additional_info = self._check_and_add_math_escapes(additional_info)
-
-            if not isinstance(additional_info, str):
+            elif not isinstance(additional_info, str):
                 raise TypeError("Additional info must be a string")
+
+            additional_info = self._check_and_add_math_escapes(additional_info)
 
             combined_info = info + "\n" + additional_info
             return combined_info

--- a/tests/fitfunctions/test_tex_info.py
+++ b/tests/fitfunctions/test_tex_info.py
@@ -101,6 +101,12 @@ def test_simplify_for_paper():
     ]
 
 
+def test_add_additional_info_with_str(texinfo):
+    base = "base"
+    result = texinfo._add_additional_info(base, "extra")
+    assert "$extra$" in result
+
+
 def test_add_additional_info(texinfo):
     base = "base"
     result = texinfo._add_additional_info(base, ["x", "y"])


### PR DESCRIPTION
## Summary
- ensure `_add_additional_info` TeX-wraps string inputs
- test TeX formatting for additional info strings

## Testing
- `black tests/fitfunctions/test_tex_info.py solarwindpy/fitfunctions/tex_info.py`
- `flake8 tests/fitfunctions/test_tex_info.py solarwindpy/fitfunctions/tex_info.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892bc348f7c832c9c21d61bb72bac75