### PR TITLE
test(fitfunctions): assert label for missing fun residual

### DIFF
--- a/tests/fitfunctions/test_plots.py
+++ b/tests/fitfunctions/test_plots.py
@@ -252,5 +252,5 @@ def test_plot_residuals_missing_fun_no_exception():
     assert len(lines) == 1
     ax.legend()
     labels = {t.get_text() for t in ax.get_legend().get_texts()}
-    assert any("Simple" in lbl for lbl in labels)
+    assert labels == {r"$\mathrm{ \; Simple}$"}
     assert ax.get_ylabel() == r"$\mathrm{Residual} \; [\%]$"


### PR DESCRIPTION
## Summary
- verify residual plots return axes and expected legend labels
- check missing `fun` attribute plots only simple residual series

## Testing
- `flake8 tests/fitfunctions/test_plots.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892c3351844832c989e29e9f5a79190